### PR TITLE
Reimplements Matrix as a turf

### DIFF
--- a/modular_darkpack/master_files/code/game/objects/matrix.dm
+++ b/modular_darkpack/master_files/code/game/objects/matrix.dm
@@ -1,68 +1,37 @@
-/obj/matrix
+#define DOAFTER_SOURCE_MATRIX "doafter_matrix"
+
+/turf/closed/indestructible/the_matrix
 	name = "matrix"
 	desc = "Suicide is no exit..."
 	icon = 'modular_darkpack/modules/deprecated/icons/props.dmi'
 	icon_state = "matrix"
-	layer = ABOVE_NORMAL_TURF_LAYER
-	anchored = TRUE
-	opacity = TRUE
-	density = TRUE
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
-	var/matrixing = FALSE
 
-/obj/matrix/attack_hand(mob/user)
+/turf/closed/indestructible/the_matrix/attack_hand(mob/user)
 	if(user.client)
-		if(!matrixing)
-			matrixing = TRUE
-			if(do_after(user, 100, src))
-				cryoMob(user, src)
-				matrixing = FALSE
-			else
-				matrixing = FALSE
+		if(do_after(user, 10 SECONDS, src, interaction_key = DOAFTER_SOURCE_MATRIX))
+			despawn_mob(user, src)
 	return TRUE
 
-// TODO: [Rebase] - Refactor to line up with new cyro pod code
-/proc/cryoMob(mob/living/mob_occupant, obj/pod)
-	if(isnpc(mob_occupant))
-		return
-	if(iscarbon(mob_occupant))
-		var/mob/living/carbon/C = mob_occupant
-		if(C.transformator)
-			qdel(C.transformator)
-	var/list/crew_member = list()
-	crew_member["name"] = mob_occupant.real_name
+/turf/closed/indestructible/the_matrix/proc/despawn_mob(mob/living/despawning_mob)
+	message_admins("[ADMIN_LOOKUP(despawning_mob)] has exited through the matrix.")
+	log_game("[despawning_mob] has exited through the matrix.")
 
-	if(mob_occupant.mind)
-		// Handle job slot/tater cleanup.
-		var/job = mob_occupant.mind.assigned_role
-		crew_member["job"] = job
-		SSjob.FreeRole(job, mob_occupant)
-//		if(LAZYLEN(mob_occupant.mind.objectives))
-//			mob_occupant.mind.objectives.Cut()
-		mob_occupant.mind.special_role = null
-	else
-		crew_member["job"] = "N/A"
+	// When TG cut cryo pods they removed freeing up roles. Hrm.
+	//SSjob.FreeRole(despawning_mob.mind.assigned_role)
 
-	if (pod)
-		pod.visible_message("\The [pod] hums and hisses as it teleports [mob_occupant.real_name].")
+	GLOB.joined_player_list -= despawning_mob.ckey
 
-	var/list/gear = list()
-	if(ishuman(mob_occupant))		// sorry simp-le-mobs deserve no mercy
-		var/mob/living/carbon/human/C = mob_occupant
-		if(C.bloodhunted)
-			SSbloodhunt.hunted -= C
-			C.bloodhunted = FALSE
-			SSbloodhunt.update_shit()
-		if(C.dna)
-			GLOB.fucking_joined -= C.dna.real_name
-		gear = C.get_all_gear()
-		for(var/obj/item/item_content as anything in gear)
-			qdel(item_content)
-		for(var/mob/living/L in mob_occupant.GetAllContents() - mob_occupant)
-			L.forceMove(pod.loc)
-		if(mob_occupant.client)
-			mob_occupant.client.screen.Cut()
-//			mob_occupant.client.screen += mob_ocupant.client.void
-			var/mob/dead/new_player/M = new /mob/dead/new_player()
-			M.key = mob_occupant.key
-	QDEL_NULL(mob_occupant)
+	//handle_objectives()
+	despawning_mob.ghostize(FALSE)
+	QDEL_NULL(despawning_mob)
+
+/turf/closed/indestructible/edge
+	name = "edge"
+	desc = null
+	icon = 'icons/turf/space.dmi'
+	icon_state = "black"
+	layer = SPACE_LAYER
+	plane = FLOOR_PLANE
+	rad_insulation = RAD_FULL_INSULATION
+
+#undef DOAFTER_SOURCE_MATRIX

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6684,6 +6684,7 @@
 #include "modular_darkpack\master_files\code\datums\actions\action.dm"
 #include "modular_darkpack\master_files\code\game\area\areas.dm"
 #include "modular_darkpack\master_files\code\game\objects\items.dm"
+#include "modular_darkpack\master_files\code\game\objects\matrix.dm"
 #include "modular_darkpack\master_files\code\game\objects\structures\ladders.dm"
 #include "modular_darkpack\master_files\code\game\turfs\turf.dm"
 #include "modular_darkpack\master_files\code\modules\client\preferences\_preference.dm"

--- a/tools/UpdatePaths/Scripts/DarkPack/35_matrix.txt
+++ b/tools/UpdatePaths/Scripts/DarkPack/35_matrix.txt
@@ -1,0 +1,1 @@
+/obj/matrix : /turf/closed/indestructible/the_matrix {@OLD}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
reticks the matrix with a rework and a bonus turf

- [ ] See if it should free up job slots.
Thinking mabye no? because we dont want like. Head roles getting replaced mid round without admin intervention i think?

I have an update paths but its gonna required a manual update to prevent double turfs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
why was this an object
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: new "edge" turf for spots where the matrix is not suited
refactor: the matrix is now turf instead of an obj
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
