### PR TITLE
converts "racks" into `/obj/structure/rack`

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -1419,10 +1419,16 @@
 		return
 	building = TRUE
 	to_chat(user, span_notice("You start constructing a rack..."))
+	// DARKPACK EDIT ADD START
+	var/obj/structure/rack/rack_choice = tgui_input_list(user, "Choose rack type", "Rack Choice", list(/obj/structure/rack, /obj/structure/rack/clothing, /obj/structure/rack/clothing_hanger, /obj/structure/rack/food))
+	if(!rack_choice)
+		return
+	// DARKPACK EDIT ADD END
 	if(do_after(user, 5 SECONDS, target = user, progress=TRUE))
 		if(!user.temporarilyRemoveItemFromInventory(src))
 			return
-		var/obj/structure/rack/R = new /obj/structure/rack(get_turf(src))
+		var/obj/structure/rack/R = new rack_choice(get_turf(src)) // DARKPACK EDIT CHANGE
+		R.dir = user.dir // DARKPACK EDIT ADD - Food rack has dirs
 		user.visible_message(span_notice("[user] assembles \a [R]."), span_notice("You assemble \a [R]."))
 		R.add_fingerprint(user)
 		qdel(src)

--- a/modular_darkpack/modules/decor/code/decor.dm
+++ b/modular_darkpack/modules/decor/code/decor.dm
@@ -159,49 +159,6 @@
 			if(V.outdoors)
 				icon_state = "[initial(icon_state)]-snow"
 
-/obj/structure/clothingrack
-	name = "clothing rack"
-	desc = "Have some clothes."
-	icon = 'modular_darkpack/modules/deprecated/icons/props.dmi'
-	icon_state = "rack"
-	layer = ABOVE_ALL_MOB_LAYER
-	anchored = TRUE
-	density = TRUE
-
-/obj/structure/clothingrack/rand
-	icon_state = "rack2"
-
-/obj/structure/clothingrack/rand/Initialize(mapload)
-	. = ..()
-	icon_state = "rack[rand(1, 5)]"
-
-/obj/structure/clothinghanger
-	name = "clothing hanger"
-	desc = "Have some clothes."
-	icon = 'modular_darkpack/modules/deprecated/icons/props.dmi'
-	icon_state = "hanger1"
-	layer = ABOVE_ALL_MOB_LAYER
-	anchored = TRUE
-	density = TRUE
-
-/obj/structure/clothinghanger/Initialize(mapload)
-	. = ..()
-	icon_state = "hanger[rand(1, 4)]"
-
-/obj/structure/foodrack
-	name = "food rack"
-	desc = "Have some food."
-	icon = 'modular_darkpack/modules/deprecated/icons/64x64.dmi'
-	icon_state = "rack2"
-	layer = ABOVE_ALL_MOB_LAYER
-	anchored = TRUE
-	density = TRUE
-	pixel_w = -16
-
-/obj/structure/foodrack/Initialize(mapload)
-	. = ..()
-	icon_state = "rack[rand(1, 5)]"
-
 //I should make these slow to move
 /obj/structure/closet/crate/dumpster
 	name = "dumpster"

--- a/modular_darkpack/modules/decor/code/racks.dm
+++ b/modular_darkpack/modules/decor/code/racks.dm
@@ -11,6 +11,7 @@
 	. = ..()
 	icon_state = "rack[rand(1, 5)]"
 
+
 /obj/structure/rack/clothing_hanger
 	name = "clothing hanger"
 	desc = "Have some clothes."
@@ -29,10 +30,11 @@
 	name = "food rack"
 	desc = "Have some food."
 	icon = 'modular_darkpack/modules/deprecated/icons/64x64.dmi'
-	icon_state = "rack2"
+	icon_state = "rack1"
 	pixel_w = -16
 
 /obj/structure/rack/food/rand
+	icon_state = "rack2"
 
 /obj/structure/rack/food/rand/Initialize(mapload)
 	. = ..()

--- a/modular_darkpack/modules/decor/code/racks.dm
+++ b/modular_darkpack/modules/decor/code/racks.dm
@@ -1,0 +1,39 @@
+/obj/structure/rack/clothing
+	name = "clothing rack"
+	desc = "Have some clothes."
+	icon = 'modular_darkpack/modules/deprecated/icons/props.dmi'
+	icon_state = "rack"
+
+/obj/structure/rack/clothing/rand
+	icon_state = "rack2"
+
+/obj/structure/rack/clothing/rand/Initialize(mapload)
+	. = ..()
+	icon_state = "rack[rand(1, 5)]"
+
+/obj/structure/rack/clothing_hanger
+	name = "clothing hanger"
+	desc = "Have some clothes."
+	icon = 'modular_darkpack/modules/deprecated/icons/props.dmi'
+	icon_state = "hanger1"
+
+/obj/structure/rack/clothing_hanger/rand
+	icon_state = "hanger2"
+
+/obj/structure/rack/clothing_hanger/rand/Initialize(mapload)
+	. = ..()
+	icon_state = "hanger[rand(1, 4)]"
+
+
+/obj/structure/rack/food
+	name = "food rack"
+	desc = "Have some food."
+	icon = 'modular_darkpack/modules/deprecated/icons/64x64.dmi'
+	icon_state = "rack2"
+	pixel_w = -16
+
+/obj/structure/rack/food/rand
+
+/obj/structure/rack/food/rand/Initialize(mapload)
+	. = ..()
+	icon_state = "rack[rand(1, 5)]"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6781,6 +6781,7 @@
 #include "modular_darkpack\modules\decor\code\decor.dm"
 #include "modular_darkpack\modules\decor\code\flags.dm"
 #include "modular_darkpack\modules\decor\code\flora.dm"
+#include "modular_darkpack\modules\decor\code\racks.dm"
 #include "modular_darkpack\modules\decor\code\signs_city.dm"
 #include "modular_darkpack\modules\decor\code\trash.dm"
 #include "modular_darkpack\modules\doors\code\door_item.dm"

--- a/tools/UpdatePaths/Scripts/DarkPack/000_racks.txt
+++ b/tools/UpdatePaths/Scripts/DarkPack/000_racks.txt
@@ -1,0 +1,6 @@
+/obj/structure/clothingrack : /obj/structure/rack/clothing {@OLD}
+/obj/structure/clothingrack/@SUBTYPES : /obj/structure/rack/clothing/@SUBTYPES {@OLD}
+/obj/structure/clothinghanger : /obj/structure/rack/clothing_hanger {@OLD}
+/obj/structure/clothinghanger/@SUBTYPES : /obj/structure/rack/clothing_hanger/@SUBTYPES {@OLD}
+/obj/structure/foodrack : /obj/structure/rack/food {@OLD}
+/obj/structure/foodrack/@SUBTYPES : /obj/structure/rack/food/@SUBTYPES {@OLD}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
subtypes racks into actual racks, and adds a choice to choose to build them with rack parts.
also seperates icon randomization into a rand subtype for two of the racks that did not have it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lets you put your coat on the coat rack
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

https://github.com/user-attachments/assets/d5ff2744-39db-49e2-b09a-fe84d133ee30


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: "racks" are now under TG racks meaning you can place stuff on them and climb them
qol: you can build our racks with rack parts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
