### PR TITLE
Decapitalize Elevator Door Left/Right

### DIFF
--- a/modular_darkpack/modules/elevators/code/elevator.dm
+++ b/modular_darkpack/modules/elevators/code/elevator.dm
@@ -1,5 +1,5 @@
 /obj/machinery/door/airlock/elevator
-	name = "Elevator Door"
+	name = "elevator door"
 	icon = 'modular_darkpack/modules/elevators/icons/doorleft.dmi'
 	icon_state = "closed"
 	abstract_type = /obj/machinery/door/airlock/elevator
@@ -35,7 +35,7 @@
 
 /obj/structure/door_assembly/elevator
 	name = "door assembly"
-	base_name = "Elevator Door"
+	base_name = "elevator door"
 	icon = 'modular_darkpack/modules/elevators/icons/doorleft.dmi'
 	icon_state = "construction"
 	abstract_type = /obj/structure/door_assembly/elevator


### PR DESCRIPTION
* Lowercase the name of Elevator Door
## About The Pull Request

Fixes https://github.com/DarkPack13/SecondCity/issues/261
## Why It's Good For The Game
## Changelog
:cl:
spellcheck: Lowercased the name of elevators
/:cl:
