### PR TITLE
Update Projectile.dm

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -162,7 +162,7 @@
 	var/impact_type
 
 	//Fancy hitscan lighting effects!
-	var/hitscan_light_intensity = 1.5
+	var/hitscan_light_intensity = 0.0 // DARKPACK EDIT CHANGE - ORIGINAL var/hitscan_light_intensity =  1.5
 	var/hitscan_light_range = 0.75
 	var/hitscan_light_color_override
 	var/muzzle_flash_intensity = 3


### PR DESCRIPTION
Zeroes out the hitscan_light_intensity variable to eliminate tracer behavior on shot.
## About The Pull Request

Fixes https://github.com/DarkPack13/SecondCity/issues/272
## Why It's Good For The Game
## Changelog
:cl:
code: hitscan_light_intensity variable set to 0.0
/:cl:
