### PR TITLE
NPC real name fix (i#254)

### DIFF
--- a/modular_darkpack/modules/npc/code/human/socialroles/__socialrole.dm
+++ b/modular_darkpack/modules/npc/code/human/socialroles/__socialrole.dm
@@ -306,6 +306,7 @@
 			set_facial_hairstyle("Shaved")
 			random_name = "[pick(f_names)] [pick(s_names)]"
 			fully_replace_character_name(newname = random_name)
+
 		set_eye_color(random_eye_color())
 
 		underwear = random_underwear(gender)


### PR DESCRIPTION

## About The Pull Request


Fixes #254 
## Why It's Good For The Game
not every npc has the illegal identity quirk
## Changelog
:cl:
fix: NPC name and real_name now match
/:cl:
