### PR TITLE
NPCs aren't braindead anymore

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -291,12 +291,12 @@
 			var/npc_message = ""
 			if(HAS_TRAIT(brain, TRAIT_GHOSTROLE_ON_REVIVE))
 				npc_message = "Soul is pending..."
-			else if(!key && !isnpc(src))
+			else if(isnpc(src)) // DARKPACK EDIT ADD START
+				npc_message = "[t_He] looks busy. Probably wise not to bother [t_him]." // DARKPACK EDIT ADD END
+			else if(!key)
 				npc_message = "[t_He] [t_is] totally catatonic. The horrors of this place must have been too much for [t_him]. Any recovery is unlikely." // DARKPACK EDIT CHANGE
-			else if(!client && !isnpc(src))
+			else if(!client)
 				npc_message ="[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon."
-			else if(isnpc(src))
-				npc_message = "[t_He] looks busy. Probably wise not to bother [t_him]."
 			if(npc_message)
 				// give some space since this is usually near the end
 				ADD_NEWLINE_IF_NECESSARY(.)


### PR DESCRIPTION
## About The Pull Request
fix #251 
<img width="364" height="207" alt="image" src="https://github.com/user-attachments/assets/7251912c-c9ac-4a9e-9251-e56d610d08d9" />

edit: wrong freaking image lol

i'm willing to remove the NPC-specific message but i like it (:
## Why It's Good For The Game
frankenstein's monster is one guy not every citizen in san francisco
## Changelog
:cl:
fix: NPCs are no longer catatonic. Just busy.
/:cl:
