### PR TITLE
Fixes windows blocking interactions with Doors if placed north of them

### DIFF
--- a/modular_darkpack/modules/doors/code/vampdoor.dm
+++ b/modular_darkpack/modules/doors/code/vampdoor.dm
@@ -11,6 +11,7 @@
 	anchored = TRUE
 	density = TRUE
 	opacity = TRUE
+	flags_1 = IGNORE_TURF_PIXEL_OFFSET_1
 	pass_flags_self = PASSDOORS
 
 	max_integrity = 350


### PR DESCRIPTION

## About The Pull Request
Fixes #320
## Why It's Good For The Game
Doors should not be treated as a tile above them.
## Changelog
:cl:
fix: Doors no longer think they are on the tile above them
/:cl:
