### PR TITLE
Inhalers in Pharmacy Shops

### DIFF
--- a/modular_darkpack/modules/retail/code/stores/pharmacy.dm
+++ b/modular_darkpack/modules/retail/code/stores/pharmacy.dm
@@ -5,7 +5,8 @@
 		new /datum/data/vending_product("potassium iodide pill bottle", /obj/item/storage/pill_bottle/potassiodide, 100),
 		new /datum/data/vending_product("latex gloves", /obj/item/clothing/gloves/vampire/latex, 150),
 		new /datum/data/vending_product("iron pill bottle", /obj/item/storage/pill_bottle/iron, 150),
+		new /datum/data/vending_product("inhaler canister", /obj/item/reagent_containers/inhaler_canister/albuterol/asthma, 150),
 		//new /datum/data/vending_product("ephedrine pill bottle", /obj/item/storage/pill_bottle/ephedrine, 200),
-		new /datum/data/vending_product("inhaler", /obj/item/inhaler/albuterol, 200),
-		new /datum/data/vending_product("box of syringes", /obj/item/storage/box/syringes, 300)
+		new /datum/data/vending_product("box of syringes", /obj/item/storage/box/syringes, 300),
+		new /datum/data/vending_product("inhaler", /obj/item/inhaler/albuterol/asthma, 400)
 	)


### PR DESCRIPTION

## About The Pull Request
Adds inhalers and refill containers to pharmacy shops, allowing anyone with the asthma quirk to not constantly end up dead.
## Why It's Good For The Game
QOL if we decide to keep the Asthma negative Quirk. Offers a way for asthmatic characters to not just die.
## Changelog
:cl:
add: Added Asthma inhalers and refill canisters for them to pharmacy shops.
/:cl:
