### PR TITLE
Remove Human Superiority 

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -123,8 +123,8 @@
 		hypercorporations buy the senate votes they need and establish territory far past the Earth Government's reach. \
 		In hypercorporation territory company policy is law, giving new meaning to \"employee termination\".",
 	)
-//Comments out the unique human quirks as we aren't using the AI.
-/*/datum/species/human/create_pref_unique_perks()
+/* // DARKPACK EDIT REMOVAL START - (We aren't using the AI, so this is currently useless and immersion breaking)
+/datum/species/human/create_pref_unique_perks()
 	var/list/to_add = list()
 
 	if(CONFIG_GET(number/default_laws) == 0 || CONFIG_GET(flag/silicon_asimov_superiority_override)) // Default lawset is set to Asimov
@@ -147,4 +147,4 @@
 		))
 
 	return to_add
-*/
+*/ // DARKPACK EDIT REMOVAL END


### PR DESCRIPTION
## About The Pull Request
Comments out the Asimov Superiority Quirk, as we aren't using an AI/cyborgs on the server, as mentioned in  #347.
<img width="1166" height="955" alt="code1" src="https://github.com/user-attachments/assets/5d88577c-1a43-4f10-8f9a-a5e635a59980" />
## Why It's Good For The Game
Immersion. 
## Changelog
:cl:
del: Removes the AI superiority quirk for humans and ghouls.
fix: fixes #347
/:cl:
