### PR TITLE
Matrixing a mob as an admin requires a confirmation

### DIFF
--- a/modular_darkpack/modules/matrix/code/matrix.dm
+++ b/modular_darkpack/modules/matrix/code/matrix.dm
@@ -34,6 +34,10 @@
 	return TRUE
 
 ADMIN_VERB_AND_CONTEXT_MENU(matrix_mob_verb, R_ADMIN, "Matrix Mob", "Matrix (despawn) a mob.", ADMIN_CATEGORY_GAME, mob/living/target in world)
+	var/confirm = tgui_alert(user, "Are you sure you want to matrix this mob?", "Confirm", list("Yes", "No"))
+	if(confirm != "Yes")
+		return
+
 	var/turf/target_turf = get_turf(target)
 	var/message = "[key_name(user)] has matrixed [target] ([target.type]) at [AREACOORD(target_turf)]"
 	message_admins(message)


### PR DESCRIPTION

## About The Pull Request
Adds a prompt to the admin mob matrix verb.
## Why It's Good For The Game
spite pr. (I accidentally deleted myself in old apoc the other day trying to `Mark Obj` for evil coder-bus)
parody with stuff like deleting something. How did I forget this.
## Changelog
:cl:
admin: admin matrixing a mob now has a prompt to confirm
/:cl:
