### PR TITLE
Fixing Spellbook Icon States

### DIFF
--- a/modular_darkpack/modules/paths/code/path.dm
+++ b/modular_darkpack/modules/paths/code/path.dm
@@ -1,5 +1,5 @@
 /datum/discipline/path
-	var/action_type = /datum/action/discipline/path
+	action_type = /datum/action/discipline/path
 	var/action_replaced = FALSE
 	selectable = FALSE //cant buy it as a ghoul
 

--- a/modular_darkpack/modules/powers/code/discipline/__discipline.dm
+++ b/modular_darkpack/modules/powers/code/discipline/__discipline.dm
@@ -10,6 +10,8 @@
 	var/clan_restricted = FALSE
 	///The root type of the powers this Discipline uses.
 	var/power_type = /datum/discipline_power
+	///What action type this Discipline is connected to
+	var/action_type = /datum/action/discipline
 	///If this Discipline can be selected at all, or has special handling.
 	var/selectable = TRUE
 

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/__vampire_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/__vampire_splat.dm
@@ -27,7 +27,7 @@
 	if (get_power(power_type))
 		return FALSE
 	var/datum/discipline/new_discipline = new power_type(level)
-	var/datum/action/discipline/adding_action = new path_discipline.action_type(new_discipline)
+	var/datum/action/discipline/adding_action = new new_discipline.action_type(new_discipline)
 	adding_action.Grant(owner)
 	LAZYADD(powers, adding_action)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Splat rework just needed conditional logic in add_power to handle for /datum/action/discipline/path rather than /datum/action/discipline which defaults to the original set of icons and icon states rather than the path specific

## Why It's Good For The Game

aysedfgjioeoie

## Changelog

:cl:

fix: fixed spellbook logic to match splat rework 

/:cl:
