### PR TITLE
Adds 1 slot to datum/storage/holster/darkpack

### DIFF
--- a/modular_darkpack/modules/clothes/code/belt.dm
+++ b/modular_darkpack/modules/clothes/code/belt.dm
@@ -1,5 +1,5 @@
 /datum/storage/holster/darkpack
-	max_slots = 2 // Pistol + a mag // TODO: Gridventory
+	max_slots = 3 // Pistol + two mags // TODO: Gridventory
 	max_total_storage = 16
 	open_sound = 'sound/items/handling/holster_open.ogg'
 	open_sound_vary = TRUE


### PR DESCRIPTION
## About The Pull Request
Fixes #473 
## Why It's Good For The Game

Restores intended functionality of the holster when playing the Federal Investigator  

## Changelog

:cl:

fix: fixed how many slots are allowed in the holster(added 1), so that that detectives can stow all the magazines with which they spawn.

/:cl:

