### PR TITLE
Slightly more modular CSS files

### DIFF
--- a/tgui/packages/tgui/index.tsx
+++ b/tgui/packages/tgui/index.tsx
@@ -6,6 +6,7 @@
 
 // Themes
 import './styles/main.scss';
+import './styles/darkpack.scss'; // DARKPACK EDIT ADD
 
 import { setupGlobalEvents } from 'tgui-core/events';
 import { setupHotKeys } from 'tgui-core/hotkeys';

--- a/tgui/packages/tgui/styles/darkpack.scss
+++ b/tgui/packages/tgui/styles/darkpack.scss
@@ -1,0 +1,13 @@
+// THIS IS A DARKPACK UI FILE
+@use 'sass:meta';
+@use 'base';
+@use '~tgui-core/styles';
+
+// Layouts
+@include meta.load-css('./interfaces/Atm.scss');
+@include meta.load-css('./interfaces/Telephone.scss');
+
+// NT Theme
+.Layout__content {
+  background-image: url('assets/bg-vtm.svg');
+}

--- a/tgui/packages/tgui/styles/main.scss
+++ b/tgui/packages/tgui/styles/main.scss
@@ -18,7 +18,6 @@
 // Interfaces
 @include meta.load-css('./interfaces/Accounting.scss');
 @include meta.load-css('./interfaces/AlertModal.scss');
-@include meta.load-css('./interfaces/Atm.scss'); // DARKPACK EDIT ADD
 @include meta.load-css('./interfaces/Changelog.scss');
 @include meta.load-css('./interfaces/CrewManifest.scss');
 @include meta.load-css('./interfaces/Emojipedia.scss');
@@ -45,7 +44,6 @@
 @include meta.load-css('./interfaces/Trophycase.scss');
 @include meta.load-css('./interfaces/Uplink.scss');
 @include meta.load-css('./interfaces/DetectiveBoard.scss');
-@include meta.load-css('./interfaces/Telephone.scss'); // DARKPACK EDIT ADD
 @include meta.load-css('./interfaces/ColorPicker.scss');
 
 // Layouts
@@ -59,7 +57,7 @@
 
 // NT Theme
 .Layout__content {
-  background-image: url('assets/bg-vtm.svg'); // DARKPACK EDIT CHANGE - VtM theme
+  background-image: url('tgui-core/assets/bg-nanotrasen.svg');
   background-size: 70% 70%;
   background-position: center;
   background-repeat: no-repeat;


### PR DESCRIPTION

## About The Pull Request
Makes our own main css file. primarily so when we override any themes its a bit cleaner.

Seems fine from testing.
<img width="736" height="542" alt="image" src="https://github.com/user-attachments/assets/00a09634-4476-4dc0-8a74-90d2567bb9b9" />
<img width="353" height="567" alt="image" src="https://github.com/user-attachments/assets/fcc5bdd7-8040-422a-8cd0-a1a5548e50af" />

