### PR TITLE
makes parent type for areas `outdoors`

### DIFF
--- a/modular_darkpack/modules/areas/code/__vtm.dm
+++ b/modular_darkpack/modules/areas/code/__vtm.dm
@@ -4,6 +4,7 @@
 	icon_state = "sewer"
 	requires_power = FALSE
 	default_gravity = STANDARD_GRAVITY
+	outdoors = TRUE
 	var/zone_type = ZONE_MASQUERADE
 
 /area/vtm/powered(chan)


### PR DESCRIPTION

## About The Pull Request
makes it outdoors. This only changes this type as we dont have many subtypes on it and they all declare their own outdoors
## Why It's Good For The Game
"fixes" #588 without addressing the bad practice behind the issue
## Changelog
:cl:
fix: some areas should be outdoors again properly (like the upper sections of the map)
/:cl:
