### PR TITLE
Removes `/trail` blood subtype from map to fix tests

### DIFF
--- a/_maps/map_files/Vampire/westfield_mall/modules/old_train_rail_2.dmm
+++ b/_maps/map_files/Vampire/westfield_mall/modules/old_train_rail_2.dmm
@@ -321,10 +321,6 @@
 /obj/machinery/chem_mass_spec,
 /turf/open/floor/city/clinic,
 /area/vtm/interior/sewer)
-"RV" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/sewer)
 "Sg" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/rough/cave,
@@ -619,7 +615,7 @@ ve
 CK
 Ig
 wn
-RV
+pP
 NG
 pP
 Ig


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Causes flaky fail as its not something meant to be mapped.