### PR TITLE
TTRPG damage now represents 10 force

### DIFF
--- a/code/__DEFINES/~darkpack/combat.dm
+++ b/code/__DEFINES/~darkpack/combat.dm
@@ -5,7 +5,7 @@
 #define SCENES * 3 MINUTES
 
 // To eyeball damage as its calcuated in the ttrpg
-#define TTRPG_DAMAGE * 5
+#define TTRPG_DAMAGE * 10
 
 // Unused for now
 #define BASHING "bashing"


### PR DESCRIPTION

## About The Pull Request
changes da define from 5 to 10
## Why It's Good For The Game
In the TTRPG you have 7 pips that have 3 states each. If you hit agg in incapacitated, you die.
In spessman game. 200 damage kills you***** 
<img width="269" height="116" alt="image" src="https://github.com/user-attachments/assets/713d2c09-4fa3-47b2-8a2b-c8b51639f17f" />
This makes it match that closer and makes actions balanced using this define stronger.
## Changelog
:cl:
balance: Doubles the define for TTRPG damage to represent 10 instead of 5 force
/:cl:
