### PR TITLE
More basic meds in the pharmacy

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -366,7 +366,7 @@
 	other_delay = 2 SECONDS
 	merge_type = /obj/item/stack/medical/bruise_pack
 	apply_verb = "applying to"
-	custom_price = 50 // DARKPACK EDIT ADD - ECONOMY
+	custom_price = 30 // DARKPACK EDIT ADD - ECONOMY
 
 /obj/item/stack/medical/bruise_pack/grind_results()
 	return list(/datum/reagent/medicine/c2/libital = 10)
@@ -385,7 +385,7 @@
 	other_delay = 2 SECONDS
 	max_amount = 12
 	amount = 6
-	custom_price = PAYCHECK_CREW * 2
+	custom_price = 25 // DARKPACK EDIT CHANGE - ECONOMY
 	absorption_rate = 0.125
 	absorption_capacity = 5
 	sanitization = 3
@@ -577,6 +577,7 @@
 	heal_begin_sound = SFX_SUTURE_BEGIN
 	heal_continuous_sound = SFX_SUTURE_CONTINUOUS
 	heal_end_sound = SFX_SUTURE_END
+	custom_price = 50 // DARKPACK EDIT ADD - ECONOMY
 
 /obj/item/stack/medical/suture/grind_results()
 	return list(/datum/reagent/medicine/spaceacillin = 2)
@@ -609,7 +610,7 @@
 	sanitization = 0.25
 	merge_type = /obj/item/stack/medical/ointment
 	apply_verb = "applying to"
-	custom_price = 50 // DARKPACK EDIT ADD - ECONOMY
+	custom_price = 30 // DARKPACK EDIT ADD - ECONOMY
 
 /obj/item/stack/medical/ointment/grind_results()
 	return list(/datum/reagent/medicine/c2/lenturi = 10)
@@ -620,7 +621,7 @@
 
 /obj/item/stack/medical/mesh
 	name = "regenerative mesh"
-	desc = "A bacteriostatic mesh used to dress burns."
+	desc = "A bacteriostatic mesh bandage used to dress burns." // DARKPACK EDIT CHANGE
 	gender = PLURAL
 	singular_name = "mesh piece"
 	icon_state = "regen_mesh"
@@ -638,6 +639,7 @@
 	heal_continuous_sound = SFX_REGEN_MESH_CONTINUOUS
 	heal_end_sound = SFX_REGEN_MESH_END
 	merge_type = /obj/item/stack/medical/mesh
+	custom_price = 50 // DARKPACK EDIT ADD - ECONOMY
 
 	///This var determines if the sterile packaging of the mesh has been opened.
 	var/is_open = TRUE

--- a/modular_darkpack/modules/retail/code/_retail.dm
+++ b/modular_darkpack/modules/retail/code/_retail.dm
@@ -2,6 +2,7 @@
 #define SANITIZED_PATH(path)(replacetext(replacetext("[path]", "/obj/item/", ""), "/", "-"))
 
 /obj/structure/retail
+	abstract_type = /obj/structure/retail
 	name = "retail outlet"
 	desc = "A counter for partaking in wretched capitalism. Takes cash or card."
 	icon = 'modular_darkpack/modules/retail/icons/vendors_shops.dmi'
@@ -13,23 +14,9 @@
 	var/is_gun_store = FALSE
 	var/payment_department = ACCOUNT_SRV
 
-	var/list/products_list = list(
-		new /datum/data/vending_product("Plain Donut", /obj/item/food/donut/plain),
-		new /datum/data/vending_product("Plain Jelly Donut", /obj/item/food/donut/jelly/plain),
-		new /datum/data/vending_product("Berry Donut", /obj/item/food/donut/berry),
-		new /datum/data/vending_product("Frosted Jelly Donut", /obj/item/food/donut/jelly/berry),
-		new /datum/data/vending_product("Purple Donut", /obj/item/food/donut/trumpet),
-		new /datum/data/vending_product("Frosted Purple-Jelly Donut", /obj/item/food/donut/jelly/trumpet),
-		new /datum/data/vending_product("Apple Donut", /obj/item/food/donut/apple),
-		new /datum/data/vending_product("Apple Jelly Donut", /obj/item/food/donut/jelly/apple),
-		new /datum/data/vending_product("Caramel Donut", /obj/item/food/donut/caramel),
-		new /datum/data/vending_product("Caramel Jelly Donut", /obj/item/food/donut/jelly/caramel),
-		new /datum/data/vending_product("Chocolate Donut", /obj/item/food/donut/choco),
-		new /datum/data/vending_product("Chocolate Custard Donut", /obj/item/food/donut/jelly/choco),
-		new /datum/data/vending_product("Matcha Donut", /obj/item/food/donut/matcha),
-		new /datum/data/vending_product("Matcha Jelly Donut", /obj/item/food/donut/jelly/matcha),
-		new /datum/data/vending_product("Blueberry Muffin", /obj/item/food/muffin/berry),
-	)
+	var/list/datum/data/vending_product/products_list = list()
+	// Equivlenet to products list if you dont need to pass args. Will likely phase out the evil news in our type path definitions
+	var/list/product_types = list()
 
 /obj/structure/retail/Initialize()
 	. = ..()
@@ -60,6 +47,8 @@
 		ui_interact(user)
 
 /obj/structure/retail/proc/build_inventory()
+	for(var/product_path in product_types)
+		products_list += new /datum/data/vending_product(path = product_path)
 	for(var/datum/data/vending_product/product in products_list)
 		if(!product)
 			CRASH("Null retail product loaded in initialization of [src]. This should not happen!")

--- a/modular_darkpack/modules/retail/code/stores/coffee_shop.dm
+++ b/modular_darkpack/modules/retail/code/stores/coffee_shop.dm
@@ -2,20 +2,20 @@
 	name = "Coffee Shop"
 	desc = "Mmmm, Donuts... Overpriced, but warm. The best you'll be getting on a night like this."
 	owner_needed = FALSE
-	products_list = list(
-		new /datum/data/vending_product("Plain Donut", /obj/item/food/donut/plain),
-		new /datum/data/vending_product("Plain Jelly Donut", /obj/item/food/donut/jelly/plain),
-		new /datum/data/vending_product("Berry Donut", /obj/item/food/donut/berry),
-		new /datum/data/vending_product("Frosted Jelly Donut", /obj/item/food/donut/jelly/berry),
-		new /datum/data/vending_product("Purple Donut", /obj/item/food/donut/trumpet),
-		new /datum/data/vending_product("Frosted Purple-Jelly Donut", /obj/item/food/donut/jelly/trumpet),
-		new /datum/data/vending_product("Apple Donut", /obj/item/food/donut/apple),
-		new /datum/data/vending_product("Apple Jelly Donut", /obj/item/food/donut/jelly/apple),
-		new /datum/data/vending_product("Caramel Donut", /obj/item/food/donut/caramel),
-		new /datum/data/vending_product("Caramel Jelly Donut", /obj/item/food/donut/jelly/caramel),
-		new /datum/data/vending_product("Chocolate Donut", /obj/item/food/donut/choco),
-		new /datum/data/vending_product("Chocolate Custard Donut", /obj/item/food/donut/jelly/choco),
-		new /datum/data/vending_product("Matcha Donut", /obj/item/food/donut/matcha),
-		new /datum/data/vending_product("Matcha Jelly Donut", /obj/item/food/donut/jelly/matcha),
-		new /datum/data/vending_product("Blueberry Muffin", /obj/item/food/muffin/berry),
+	product_types = list(
+		/obj/item/food/donut/plain,
+		/obj/item/food/donut/jelly/plain,
+		/obj/item/food/donut/berry,
+		/obj/item/food/donut/jelly/berry,
+		/obj/item/food/donut/trumpet,
+		/obj/item/food/donut/jelly/trumpet,
+		/obj/item/food/donut/apple,
+		/obj/item/food/donut/jelly/apple,
+		/obj/item/food/donut/caramel,
+		/obj/item/food/donut/jelly/caramel,
+		/obj/item/food/donut/choco,
+		/obj/item/food/donut/jelly/choco,
+		/obj/item/food/donut/matcha,
+		/obj/item/food/donut/jelly/matcha,
+		/obj/item/food/muffin/berry,
 	)

--- a/modular_darkpack/modules/retail/code/stores/pharmacy.dm
+++ b/modular_darkpack/modules/retail/code/stores/pharmacy.dm
@@ -1,7 +1,12 @@
 /obj/structure/retail/pharmacy
+	product_types = list(
+		/obj/item/stack/medical/bruise_pack,
+		/obj/item/stack/medical/ointment,
+		/obj/item/stack/medical/gauze,
+		/obj/item/stack/medical/suture,
+		/obj/item/stack/medical/mesh,
+	)
 	products_list = list(
-		new /datum/data/vending_product("bruise pack", /obj/item/stack/medical/bruise_pack),
-		new /datum/data/vending_product("burn ointment", /obj/item/stack/medical/ointment),
 		new /datum/data/vending_product("potassium iodide pill bottle", /obj/item/storage/pill_bottle/potassiodide),
 		new /datum/data/vending_product("latex gloves", /obj/item/clothing/gloves/vampire/latex, 150),
 		new /datum/data/vending_product("iron pill bottle", /obj/item/storage/pill_bottle/iron, 150),

--- a/modular_darkpack/modules/retail/code/vending_product.dm
+++ b/modular_darkpack/modules/retail/code/vending_product.dm
@@ -1,7 +1,7 @@
 /datum/data/vending_product
 	var/icon_dimension
 
-/datum/data/vending_product/New(name = "product", path, price, amount = -1)
+/datum/data/vending_product/New(name, path, price, amount = -1)
 	src.name = name
 	src.product_path = path
 	src.price = price
@@ -10,6 +10,9 @@
 	var/obj/item/item = product_path
 	if(!item)
 		CRASH("Retail product equipment path of [product_path] is not a valid path!")
+
+	if(!name)
+		src.name = item::name
 
 	if(!price)
 		src.price = item.custom_price || item.custom_premium_price


### PR DESCRIPTION

## About The Pull Request
apparently brute packs dont heal wounds/blood loss which became an issue. So i gave the shop sutures, gauze, and mesh. Also made bruise and ontiment cheaper as 50 bucks is kinda mad even with American health insurance issues lol.
<img width="431" height="549" alt="image" src="https://github.com/user-attachments/assets/ff02a8f4-47ec-4eb1-b3c9-2783e1989e0e" />

also some back-end changes to default to their actual name easier. 
<img width="477" height="613" alt="image" src="https://github.com/user-attachments/assets/d482f14c-2c0a-4165-abae-0362c20c1cc4" />
TO
<img width="398" height="512" alt="image" src="https://github.com/user-attachments/assets/3acdc7b5-16f5-4672-9817-5962067f1cda" />
## Why It's Good For The Game
People should be able to treat all basic wounds with the pharmacy shop. Especially to supplement a doctor not being online.

and for the names, outside a few instances, its likely better to adjust the actual name of the item rather then the shop (spaceman's donut for example)
## Changelog
:cl:
add: Pharmacy has sutures, gauze, and mesh
balance: bruise packs and ointment is cheaper
/:cl:
