### PR TITLE
Readds player masqs reports

### DIFF
--- a/modular_darkpack/master_files/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_darkpack/master_files/code/modules/mob/living/carbon/human/human.dm
@@ -9,12 +9,14 @@
 		if(usr == src)
 			return
 		var/reason = tgui_input_text(reporter, "Write a description of violation", "Spot a Masquerade violation", null, MAX_MESSAGE_LEN)
-		if(reason)
-			reason = sanitize(reason)
-			message_admins("[ADMIN_LOOKUPFLW(reporter)] spotted [ADMIN_LOOKUPFLW(src)]'s Masquerade violation. Description: [reason]")
-			log_game("[ADMIN_LOOKUPFLW(reporter)] spotted [ADMIN_LOOKUPFLW(src)]'s Masquerade violation. Description: [reason]")
-			SEND_SIGNAL(reporter, COMSIG_SEEN_MASQUERADE_VIOLATION, src)
-			to_chat(src, span_danger("You were found to be violating the masquereade for: [reason]"))
+		if(!reason)
+			return
+		reason = sanitize(reason)
+		if(!SEND_SIGNAL(reporter, COMSIG_SEEN_MASQUERADE_VIOLATION, src))
+			return
+		message_admins("[ADMIN_LOOKUPFLW(reporter)] spotted [ADMIN_LOOKUPFLW(src)]'s Masquerade violation. Description: [reason]")
+		log_game("[ADMIN_LOOKUPFLW(reporter)] spotted [ADMIN_LOOKUPFLW(src)]'s Masquerade violation. Description: [reason]")
+		to_chat(src, span_danger("You were found to be violating the masquereade for: [reason]"))
 
 	if(href_list["masquerade_reinforcement"])
 		if(!ismundane(usr))
@@ -24,8 +26,10 @@
 			return
 		if(usr == src)
 			return
+		if(!SEND_SIGNAL(reporter, COMSIG_MASQUERADE_REINFORCE, src))
+			return
 		message_admins("[ADMIN_LOOKUPFLW(reporter)] repaired [ADMIN_LOOKUPFLW(src)]'s Masquerade violation.")
 		log_game("[ADMIN_LOOKUPFLW(reporter)] repaired [ADMIN_LOOKUPFLW(src)]'s Masquerade violation.")
-		SEND_SIGNAL(reporter, COMSIG_ALL_MASQUERADE_REINFORCE, src)
+
 
 	. = ..()

--- a/modular_darkpack/modules/masquerade/code/components/violation_observer.dm
+++ b/modular_darkpack/modules/masquerade/code/components/violation_observer.dm
@@ -45,13 +45,18 @@
 	breached_players += player_breacher
 	SSmasquerade.masquerade_breach(source, player_breacher, (isliving(source) ? MASQUERADE_REASON_NPC : MASQUERADE_REASON_OBJECT))
 
+	return TRUE
+
 /datum/component/violation_observer/proc/on_masquerade_violation_reinforced(atom/source, mob/living/player_breacher)
 	SIGNAL_HANDLER
 
-	SEND_SIGNAL(source, COMSIG_MASQUERADE_HUD_DELETE, player_breacher)
-	SSmasquerade.masquerade_reinforce(source, player_breacher)
-	source.observe_masquerade_reinforce(player_breacher)
-	breached_players -= player_breacher
+	if(player_breacher in breached_players)
+		SEND_SIGNAL(source, COMSIG_MASQUERADE_HUD_DELETE, player_breacher)
+		SSmasquerade.masquerade_reinforce(source, player_breacher)
+		source.observe_masquerade_reinforce(player_breacher)
+		breached_players -= player_breacher
+
+		return TRUE
 
 /datum/component/violation_observer/proc/on_death(atom/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
readds the backend for the report buttons, a report needs a reason to actually be considered and its logged to admins.
fixed double reinforcements by actually verifying the guy is in the list.

https://github.com/user-attachments/assets/b0994039-77d6-40e2-ab3d-2a93d6dbcac1
## Why It's Good For The Game
Better then nothing, though i still find it being locked to mundane to be overly restrictive to how the masq and veil actually work.
## Changelog
:cl:
add: re-adds reporting masquerade violations and reinforcements
/:cl:
