### PR TITLE
Necromancy Tome Fix

### DIFF
--- a/modular_darkpack/modules/jobs/code/giovanni/capo.dm
+++ b/modular_darkpack/modules/jobs/code/giovanni/capo.dm
@@ -29,4 +29,4 @@
 	shoes = /obj/item/clothing/shoes/vampire
 	l_pocket = /obj/item/smartphone/giovanni_capo
 	r_pocket = /obj/item/vamp/keys/capo
-	backpack_contents = list(/obj/item/card/credit/giovanniboss=1)
+	backpack_contents = list(/obj/item/card/credit/giovanniboss=1, /obj/item/ritual_tome/necromancy=1)

--- a/modular_darkpack/modules/jobs/code/giovanni/la_squadra.dm
+++ b/modular_darkpack/modules/jobs/code/giovanni/la_squadra.dm
@@ -29,4 +29,4 @@
 	shoes = /obj/item/clothing/shoes/vampire
 	l_pocket = /obj/item/smartphone/giovanni_squadra
 	r_pocket = /obj/item/vamp/keys/giovanni
-	backpack_contents = list(/obj/item/card/credit/rich=1)
+	backpack_contents = list(/obj/item/card/credit/rich=1, /obj/item/ritual_tome/necromancy=1)


### PR DESCRIPTION

## About The Pull Request

Adds Necromancy Tomes to the relevant Giovanni role inventories.

## Why It's Good For The Game

Engaging with intended content is good 

Fixes: https://github.com/DarkPack13/SecondCity/issues/586
## Changelog
:cl:
fix: Necromancy tomes will properly spawn for Capo/La Squadra Roles
/:cl:
