### PR TITLE
Shroudsight TTRPG accuracy

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/necromancy.dm
+++ b/modular_darkpack/modules/powers/code/discipline/necromancy.dm
@@ -24,7 +24,7 @@
 	name = "Necromancy power name"
 	desc = "Necromancy power description"
 
-//SHROUDSIGHT V20 p.
+//SHROUDSIGHT V20 p. 163
 /datum/storyteller_roll/shroudsight
 	bumper_text = "shroudsight"
 	applicable_stats = list(STAT_PERCEPTION, STAT_AWARENESS)


### PR DESCRIPTION
## About The Pull Request
Oh this aint ttrpg accruate. I dont know how but i landed on this while looking at stuff and realized you do NOT get night vision and its also is a roll.

<img width="423" height="286" alt="image" src="https://github.com/user-attachments/assets/cdeeeed2-3701-4b27-bd6a-c862e7831dd4" />

## Why It's Good For The Game
Night vision for vampire is actually surprisingly hard to find. (Outside COD mabye??) your are not necessarily meant to be adapted to the night as its a curse. TTRPG accuracy.

## Changelog
:cl:
balance: Removed shroudsights night vision
balance: Shroud sight requires a perception + awareness roll
/:cl:
