### PR TITLE
Fixing clanmark and gargoyle leg and tail bug

### DIFF
--- a/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clan_mark_pref.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clan_mark_pref.dm
@@ -54,8 +54,6 @@
 		return FALSE
 	var/clan_type = preferences.read_preference(/datum/preference/choiced/subsplat/vampire_clan)
 	var/datum/subsplat/vampire_clan/clan = get_vampire_clan(clan_type)
-	if(!clan)
-		return FALSE
 	if(istype(clan, /datum/subsplat/vampire_clan/gargoyle))
 		return TRUE
 	return FALSE


### PR DESCRIPTION
## About The Pull Request

Noticed that gargoyle leg and tail checkbox and clan beastmark feature was being displayed for all vampires, not just those with that relevant feature, so I made sure the proc returns false if all conditions fail, extra safety in garg legs and tail's apply_to_human aswell to avoid ventrues with gargoyle legs

also removed a duplicate comment from garg legs and tail proc that was copy pasted

## Why It's Good For The Game

bugfix

## Changelog
:cl:

fix: added safety checks for gargoyle tail and legs and beastmarks

/:cl:
