### PR TITLE
Billiard QOL

### DIFF
--- a/modular_darkpack/modules/billiards/code/billiard.dm
+++ b/modular_darkpack/modules/billiards/code/billiard.dm
@@ -115,7 +115,7 @@
 	. = ..()
 
 	if(istype(held_item, /obj/item/pool_cue))
-		context[SCREENTIP_CONTEXT_LMB] = "Strike ball"
+		context[SCREENTIP_CONTEXT_RMB] = "Strike ball"
 		. = CONTEXTUAL_SCREENTIP_SET
 	else if(!held_item)
 		context[SCREENTIP_CONTEXT_RMB] = "Reset Table"
@@ -123,7 +123,8 @@
 
 	return . || NONE
 
-/obj/structure/table/wood/billiard/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+/obj/structure/table/wood/billiard/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
 	if(istype(tool, /obj/item/pool_cue))
 		var/static/list/cue_options = list(
 			SOLID_BALL = image(icon = 'modular_darkpack/modules/billiards/icons/billiard.dmi', icon_state = "1ball"),
@@ -150,7 +151,8 @@
 		for(var/i in 1 to amount_to_hit_result)
 			if(!length(get_balls_on_table()))
 				break
-			sink_ball(user, choice, accuracy_result, amount_to_hit_result, balls_sunk = balls_sunk)
+			if(!sink_ball(user, choice, accuracy_result, amount_to_hit_result, balls_sunk = balls_sunk))
+				break
 		if(length(balls_sunk))
 			user.visible_message(span_notice("[user] sinks [jointext(balls_sunk, ", ")]. [length(get_balls_on_table())] left."), span_notice("You sink [jointext(balls_sunk, ", ")]!"))
 		return ITEM_INTERACT_SUCCESS
@@ -193,6 +195,7 @@
 	for(var/obj/item/pool_ball/ball in get_balls_on_table(list(SOLID_BALL, STRIPED_BALL, EIGHT_BALL, ZERO_BALL)))
 		if(prob(50 + amount_to_hit_result * 10))
 			animate(ball, time = rand(0.5 SECONDS, 3 SECONDS) , pixel_x = rand(-TABLE_BOUNDS, TABLE_BOUNDS), pixel_y = rand(-TABLE_BOUNDS-6, TABLE_BOUNDS), easing = CUBIC_EASING|EASE_OUT)
+	return TRUE
 
 /obj/structure/table/wood/billiard/proc/random_ball(desired_ball_type, accuracy_result = ROLL_SUCCESS)
 	var/balls_to_get


### PR DESCRIPTION

## About The Pull Request
Some tweaks after feedback.
## Why It's Good For The Game
It was spammy and hitting the wrong balls despite a billion successes is bad!
Its fine mostly at low stats but when you have high stats it can run out of balls your actually aiming for plus random chance outside the roll.
## Changelog
:cl:
qol: Balls hit in billiards are now purely based on success rather success being a modifier.
qol: Hit balls are all displayed on a single line to avoid spam.
qol: Moved striking ball to right click to allow you to place the cue back onto the table
/:cl:
