### PR TITLE
dice outputs and their consequences

### DIFF
--- a/modular_darkpack/modules/storyteller_dice/code/rolling_pref.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/rolling_pref.dm
@@ -5,3 +5,6 @@
 
 /datum/preference/choiced/dice_output/init_possible_values()
 	return list(DICE_OUTPUT_BALLOON, DICE_OUTPUT_CHAT)
+
+/datum/preference/choiced/dice_output/create_default_value()
+	return DICE_OUTPUT_CHAT


### PR DESCRIPTION

## About The Pull Request

makes dice output not be a balloon alert by default

## Why It's Good For The Game

because having random numbers fly over your head with no explanation is bad for new players

## Changelog
:cl:
qol: dice results now output to chat by default instead of balloon alerts
/:cl:
