### PR TITLE
endron bouncers n cam bouncers

### DIFF
--- a/modular_darkpack/modules/vip_areas/code/bouncer_roles/bouncer_elysium_role.dm
+++ b/modular_darkpack/modules/vip_areas/code/bouncer_roles/bouncer_elysium_role.dm
@@ -1,3 +1,10 @@
 /datum/socialrole/bouncer/elysium
-	suits = list(/obj/item/clothing/suit/vampire/trench)
-	glasses = list(/obj/item/clothing/glasses/sunglasses)
+	bouncer_weapon_type = /obj/item/gun/ballistic/automatic/darkpack/mp5
+	bouncer_backup_weapon_type = /obj/item/melee/baton/vamp
+	shoes = list(/obj/item/clothing/shoes/vampire/jackboots)
+	uniforms = list(/obj/item/clothing/under/vampire/turtleneck_red)
+	pockets = list(/obj/item/vamp/keys/npc, /obj/item/stack/dollar/rand)
+	gloves = list(/obj/item/clothing/gloves/vampire/work)
+	suits = list(/obj/item/clothing/suit/vampire/vest)
+	glasses = list(/obj/item/clothing/glasses/vampire/sun)
+	hats = list(/obj/item/clothing/head/beret/black)

--- a/modular_darkpack/modules/vip_areas/code/bouncer_roles/bouncer_endron_role.dm
+++ b/modular_darkpack/modules/vip_areas/code/bouncer_roles/bouncer_endron_role.dm
@@ -4,7 +4,7 @@
 	bouncer_weapon_type = /obj/item/gun/ballistic/automatic/darkpack/mp5
 	bouncer_backup_weapon_type = /obj/item/melee/baton/vamp
 	shoes = list(/obj/item/clothing/shoes/vampire/jackboots)
-	//uniforms = list(/obj/item/clothing/under/pentex/pentex_turtleneck)
+	uniforms = list(/obj/item/clothing/under/vampire/pentex_turtleneck)
 	pockets = list(/obj/item/vamp/keys/npc, /obj/item/stack/dollar/rand)
 	gloves = list(/obj/item/clothing/gloves/vampire/work)
 	suits = list(/obj/item/clothing/suit/vampire/vest)
@@ -16,7 +16,7 @@
 	bouncer_weapon_type = /obj/item/gun/ballistic/automatic/darkpack/mp5
 	bouncer_backup_weapon_type = /obj/item/melee/baton/vamp
 	shoes = list(/obj/item/clothing/shoes/vampire/jackboots)
-	//uniforms = list(/obj/item/clothing/under/pentex/pentex_janitor)
+	uniforms = list(/obj/item/clothing/under/vampire/pentex_janitor)
 	pockets = list(/obj/item/vamp/keys/npc, /obj/item/stack/dollar/rand)
 	gloves = list(/obj/item/clothing/gloves/vampire/latex)
 	suits = list(/obj/item/clothing/suit/vampire/vest)
@@ -28,7 +28,7 @@
 	bouncer_weapon_type = /obj/item/gun/ballistic/automatic/darkpack/mp5
 	bouncer_backup_weapon_type = /obj/item/melee/baton/vamp
 	shoes = list(/obj/item/clothing/shoes/vampire/jackboots)
-	//uniforms = list(/obj/item/clothing/under/pentex/pentex_janitor)
+	uniforms = list(/obj/item/clothing/under/vampire/pentex_janitor)
 	pockets = list(/obj/item/vamp/keys/npc, /obj/item/stack/dollar/rand)
 	gloves = list(/obj/item/clothing/gloves/vampire/latex)
 	suits = list(/obj/item/clothing/suit/vampire/vest)
@@ -40,7 +40,7 @@
 	bouncer_weapon_type = /obj/item/gun/ballistic/automatic/pistol/darkpack/deagle
 	bouncer_backup_weapon_type = /obj/item/melee/baton/vamp
 	shoes = list(/obj/item/clothing/shoes/vampire/jackboots)
-	//uniforms = list(/obj/item/clothing/under/pentex/pentex_suit)
+	uniforms = list(/obj/item/clothing/under/vampire/pentex_suit)
 	pockets = list(/obj/item/vamp/keys/npc, /obj/item/stack/dollar/rand)
 	gloves = list(/obj/item/clothing/gloves/vampire/work)
 	suits = list(/obj/item/clothing/suit/vampire/vest)


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/DarkPack13/SecondCity/issues/527

changes camarilla bouncers to be wearing a red turtleneck bulletproof vest balaclava combo

<img width="506" height="101" alt="image" src="https://github.com/user-attachments/assets/a2c822dd-5bac-4c42-afea-456a09f11841" />

little errors are from the MP5 not having a worn sprite, will work that out later

## Why It's Good For The Game

bugfix and personal preference

## Changelog
:cl:
fix: endron bouncers now wear the correct uniforms, camarilla bouncers now wear red turtlenecks and armoured vests
/:cl:
