### PR TITLE
Aura layers under mob

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/auspex/aura_component.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/aura_component.dm
@@ -1,3 +1,5 @@
+#define AUSPEX_LAYER BELOW_MOB_LAYER
+
 /datum/atom_hud/data/auspex_aura
 	hud_icons = list(AUSPEX_AURA_HUD)
 
@@ -41,7 +43,7 @@
 	var/image/holder = parent_mob.hud_list[AUSPEX_AURA_HUD]
 	if(!holder)
 		holder = new
-	var/mutable_appearance/aura_appearance = mutable_appearance('modular_darkpack/modules/powers/icons/auras.dmi', "aura", ABOVE_MOB_LAYER, parent_mob, GAME_PLANE)
+	var/mutable_appearance/aura_appearance = mutable_appearance('modular_darkpack/modules/powers/icons/auras.dmi', "aura", AUSPEX_LAYER, parent_mob, GAME_PLANE)
 	update_aura_colors(aura_appearance, holder)
 	update_aura_overlays(aura_appearance, holder)
 	update_aura_filters(aura_appearance, holder)
@@ -64,7 +66,7 @@
 	var/mob/parent_mob = parent
 	if(iskindred(parent_mob))
 		var/icon/temporary_icon_holder = holder.appearance
-		var/mutable_appearance/aura_image = mutable_appearance(temporary_icon_holder, "aura", ABOVE_MOB_LAYER, parent_mob, GAME_PLANE)
+		var/mutable_appearance/aura_image = mutable_appearance(temporary_icon_holder, "aura", AUSPEX_LAYER, parent_mob, GAME_PLANE)
 
 		var/list/hsv_color_value = rgb2hsv(holder.color)
 		hsv_color_value[2] = hsv_color_value[2] * 0.7 // Reduce saturation for kindred
@@ -75,7 +77,7 @@
 	// DARKPACK TODO - aura still needs real sprites.
 	if(HAS_TRAIT(parent_mob, TRAIT_FRENETIC_AURA))
 		var/icon/temporary_icon_holder = holder.appearance
-		var/mutable_appearance/aura_image = mutable_appearance(temporary_icon_holder, "old_aura_bright", ABOVE_MOB_LAYER, parent_mob, GAME_PLANE)
+		var/mutable_appearance/aura_image = mutable_appearance(temporary_icon_holder, "old_aura_bright", AUSPEX_LAYER, parent_mob, GAME_PLANE)
 
 		var/list/hsv_color_value = rgb2hsv(holder.color)
 		hsv_color_value[2] = hsv_color_value[2] * 1.5 // Way brighter for shapeshifters
@@ -95,13 +97,13 @@
 	if(current_aura == AURA_ANXIOUS)
 		var/icon/temporary_icon_holder = icon('modular_darkpack/modules/powers/icons/auras.dmi', "aura")
 		var/icon/static_icon = getStaticIcon(temporary_icon_holder)
-		var/mutable_appearance/static_image = mutable_appearance(static_icon, "aura", ABOVE_MOB_LAYER+2, parent_mob, GAME_PLANE)
+		var/mutable_appearance/static_image = mutable_appearance(static_icon, "aura", AUSPEX_LAYER+0.01, parent_mob, GAME_PLANE)
 		static_image.appearance_flags |= RESET_COLOR
 		holder.add_overlay(static_image)
 
 	if(isghoul(parent_mob))
 		var/icon/temporary_icon_holder = icon('modular_darkpack/modules/powers/icons/auras.dmi', "aurablotch")
-		var/mutable_appearance/aura_blotches = mutable_appearance(temporary_icon_holder, "aurablotch", ABOVE_MOB_LAYER+3, parent_mob, GAME_PLANE)
+		var/mutable_appearance/aura_blotches = mutable_appearance(temporary_icon_holder, "aurablotch", AUSPEX_LAYER+0.02, parent_mob, GAME_PLANE)
 
 		var/list/hsv_color_value = rgb2hsv(aura_appearance.color)
 		hsv_color_value[2] = hsv_color_value[2] * 0.7 // Reduce saturation for ghouls
@@ -122,3 +124,4 @@
 	if(HAS_TRAIT(parent_mob, TRAIT_IN_FRENZY))
 		apply_wibbly_filters(holder)
 
+#undef AUSPEX_LAYER


### PR DESCRIPTION

## About The Pull Request
Swaps the layer to under mobs instead of above (expect for diab aura as it would otherwise be invisible, though its still kinda hard to see.)
## Why It's Good For The Game
The aura is really obstructive and makes characters really hard to read.
## Changelog
:cl:
qol: Auras now layer underneath the mob
/:cl:
