### PR TITLE
Bloodheal isn't instant, but if it is it rolls.

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/__discipline.dm
+++ b/modular_darkpack/modules/powers/code/discipline/__discipline.dm
@@ -63,9 +63,6 @@
 	if (level == src.level)
 		return
 
-	if(level > length(all_powers)) // the amount of disc levels we are trying to give is greater than the amount of subtypes that exist for it
-		level = length(all_powers) // so only give what exists
-
 	var/list/datum/discipline_power/new_known_powers = list()
 	for (var/i in 1 to level)
 		if (length(known_powers) >= level)


### PR DESCRIPTION

## About The Pull Request

Book has a delay for bloodheal but you can skip it and roll instead. Modeled in this instance simply by doing anything to interrupt the do_after.
<img width="524" height="412" alt="image" src="https://github.com/user-attachments/assets/cc8b28dc-3c4a-48bc-abc4-b1ae6bc11ddd" />
## Why It's Good For The Game

Healing instantly from near-dead to full-health is unpleasant. This makes it so you at least have to roll and risk your blood or even more damage to do so.
## Changelog
:cl
balance: Bloodheal now has a delay, which can be interrupted to instead roll for an instant bloodheal at risk of losing blood in a failure.
/:cl:
