### PR TITLE
Recalcuate buffs on stat changes

### DIFF
--- a/modular_darkpack/modules/storyteller_stats/code/mob_affecting_adjustments/mob_procs.dm
+++ b/modular_darkpack/modules/storyteller_stats/code/mob_affecting_adjustments/mob_procs.dm
@@ -46,7 +46,7 @@
 	for(var/stat_typepath in storyteller_stats)
 		var/datum/st_stat/stat_datum = storyteller_stats[stat_typepath]
 		if(stat_datum.stat_flags & AFFECTS_HEALTH)
-			recalculate_max_health(initial = TRUE)
+			recalculate_max_health(initial)
 		if(stat_datum.stat_flags & AFFECTS_SPEED)
 			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/dexterity, multiplicative_slowdown = -(st_get_stat(STAT_DEXTERITY) / 20))
 


### PR DESCRIPTION

## About The Pull Request

Shifts the code around so that it calls the same proc it doesnt in pref load that updates speed and health mods from stats.

<img width="497" height="343" alt="image" src="https://github.com/user-attachments/assets/c7d006a8-7cfd-4a1a-8091-cd952edcf582" />
<img width="494" height="340" alt="image" src="https://github.com/user-attachments/assets/32c17e64-8be5-45ef-afb4-bb2744388a43" />


I think this is a stealth buff to a few discs like celerity but there default speed buffs can just be tweaked a little.
## Why It's Good For The Game
Right now stam is functionally useless from shifting crinos form and it means they dont really get the "soak" they should.
This helps adress that and stuff that buffs dex.
Not my favorite peice of code however as it recalucates a bit wastefully and should prob be made per stat rather then how it works rn.
## Changelog
:cl:
fix: Garou now properly get a small health boost according to the stam bonus the forms provide
code: Updating a stat properly updates all modifers for stats
/:cl:
