### PR TITLE
Fetch enlightenment directly from path. Take 2

### DIFF
--- a/modular_darkpack/modules/blood_drinking/code/bite_helper_procs.dm
+++ b/modular_darkpack/modules/blood_drinking/code/bite_helper_procs.dm
@@ -5,7 +5,7 @@
 
 	var/datum/splat/vampire/kindred/kindred_splat = get_kindred_splat(src)
 	if(kindred_splat)
-		var/hunger_threshold = 7 - (kindred_splat.enlightenment ? st_get_stat(STAT_INSTINCT) : st_get_stat(STAT_SELF_CONTROL))
+		var/hunger_threshold = 7 - (is_enlightenment() ? st_get_stat(STAT_INSTINCT) : st_get_stat(STAT_SELF_CONTROL))
 		var/previous_hunger = HAS_TRAIT(src, TRAIT_NEEDS_BLOOD)
 		var/will_be_hungry = (clamp(bloodpool + amount, 0, maxbloodpool) < hunger_threshold)
 

--- a/modular_darkpack/modules/blood_drinking/code/vamp_bite.dm
+++ b/modular_darkpack/modules/blood_drinking/code/vamp_bite.dm
@@ -40,8 +40,7 @@
 			var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 			if(!skipface)
 				if(get_kindred_splat(src) && HAS_TRAIT(src, TRAIT_NEEDS_BLOOD))
-					var/datum/splat/vampire/kindred/kindred_species = get_kindred_splat(src)
-					var/stat_to_roll = kindred_species.enlightenment ? STAT_INSTINCT : STAT_SELF_CONTROL
+					var/stat_to_roll = is_enlightenment() ? STAT_INSTINCT : STAT_SELF_CONTROL
 					var/datum/storyteller_roll/frezy_roll = new()
 					frezy_roll.applicable_stats = list(stat_to_roll)
 					var/frenzy_result = frezy_roll.st_roll(src, bit_living)

--- a/modular_darkpack/modules/city_time/code/status_effects.dm
+++ b/modular_darkpack/modules/city_time/code/status_effects.dm
@@ -30,7 +30,7 @@
 	if(!kindred_owner)
 		return FALSE
 	// Humanity 10 vamps are immume to the light. atleast for the amount of time our day lasts.
-	if(CONFIG_GET(flag/humanity_sunlight_resistance) && !kindred_owner.enlightenment && (owner.st_get_stat(STAT_MORALITY) >= 10))
+	if(CONFIG_GET(flag/humanity_sunlight_resistance) && !owner.is_enlightenment() && (owner.st_get_stat(STAT_MORALITY) >= 10))
 		return FALSE
 
 	to_chat(owner, span_danger("THE SUN SEARS YOUR FLESH"))

--- a/modular_darkpack/modules/economy/code/selling/lombard.dm
+++ b/modular_darkpack/modules/economy/code/selling/lombard.dm
@@ -173,8 +173,7 @@
 	// Morality loss warning for bulk sales
 	if(selling_comp.humanity_loss && ishuman(user))
 		var/mob/living/carbon/human/H = user
-		var/datum/splat/vampire/kindred/vampirism = get_kindred_splat(H)
-		if(!get_kindred_splat(H) || !vampirism.enlightenment)
+		if(!get_kindred_splat(H) || !H.is_enlightenment())
 			var/humanity_loss_modifier = HAS_TRAIT(H, TRAIT_SENSITIVE_HUMANITY) ? 2 : 1
 			var/total_humanity_risk = length(items_to_sell) * humanity_loss_modifier * selling_comp.humanity_loss
 

--- a/modular_darkpack/modules/economy/code/selling/selling.dm
+++ b/modular_darkpack/modules/economy/code/selling/selling.dm
@@ -56,8 +56,7 @@
 
 	// If we found a seller and they're on Enlightenment path, no warning
 	if(seller && get_kindred_splat(seller))
-		var/datum/splat/vampire/kindred/vampirism = get_kindred_splat(seller)
-		if(vampirism.enlightenment)
+		if(seller.is_enlightenment())
 			return span_notice("You've sold [parent]!")
 
 	// Default warning for Humanity path or non-vampires

--- a/modular_darkpack/modules/powers/code/discipline/dementation.dm
+++ b/modular_darkpack/modules/powers/code/discipline/dementation.dm
@@ -135,8 +135,7 @@ pools for a turn or two after the manifestation.
 /datum/discipline_power/dementation/the_haunting/pre_activation_checks(mob/living/carbon/human/target)
 	var/resistence_stat = target.st_get_stat(STAT_SELF_CONTROL)
 	if(get_kindred_splat(target))
-		var/datum/splat/vampire/kindred/target_species = get_kindred_splat(target)
-		resistence_stat = target.st_get_stat(target_species.enlightenment ? STAT_CONVICTION : STAT_SELF_CONTROL)
+		resistence_stat = target.st_get_stat(owner.is_enlightenment() ? STAT_CONVICTION : STAT_SELF_CONTROL)
 	var/theirpower = target.st_get_stat(STAT_PERCEPTION) + resistence_stat
 	mypower = SSroll.storyteller_roll(owner.st_get_stat(STAT_MANIPULATION) + owner.st_get_stat(STAT_SUBTERFUGE), theirpower, owner, numerical = TRUE)
 	if(mypower <= 0)

--- a/modular_darkpack/modules/storyteller_stats/code/st_stats/base_type/_morality.dm
+++ b/modular_darkpack/modules/storyteller_stats/code/st_stats/base_type/_morality.dm
@@ -5,4 +5,4 @@
 	min_score = 0
 	max_score = 10
 	points = 0
-	//freebie_point_cost = FREEBIE_COST_HUMANITY
+	// freebie_point_cost = FREEBIE_COST_HUMANITY

--- a/modular_darkpack/modules/storyteller_stats/code/st_stats/base_type/_path.dm
+++ b/modular_darkpack/modules/storyteller_stats/code/st_stats/base_type/_path.dm
@@ -1,5 +1,0 @@
-/datum/st_stat/morality_path
-	abstract_type = /datum/st_stat/morality_path
-	category = "Morality Path"
-	starting_score = 7
-	freebie_point_cost = FREEBIE_COST_HUMANITY

--- a/modular_darkpack/modules/vampire_the_masquerade/code/kindred/humanity.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/kindred/humanity.dm
@@ -2,7 +2,7 @@
 	SIGNAL_HANDLER
 
 	// "Enlightenment" is essentially the Path of Pure Evil. Inverts Humanity changes and limits.
-	var/is_enlightenment = enlightenment
+	var/is_enlightenment = owner.is_enlightenment()
 	var/path = is_enlightenment ? "Enlightenment" : "Humanity"
 	if (is_enlightenment && !forced)
 		value = -value

--- a/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/morality.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/morality.dm
@@ -40,7 +40,11 @@
 
 	stat_morality.morality_path = new value(target)
 
+/mob/living/proc/is_enlightenment()
+	var/datum/st_stat/morality_path/morality/stat_morality = storyteller_stats[STAT_MORALITY]
+	if(!stat_morality?.morality_path)
+		return FALSE
+
 	if(stat_morality.morality_path.alignment == MORALITY_ENLIGHTENMENT)
-		var/datum/splat/vampire/kindred/kindred_splat = get_kindred_splat(target)
-		if(istype(kindred_splat))
-			kindred_splat.enlightenment = TRUE
+		return TRUE
+	return FALSE

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/kindred_splat/kindred_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/kindred_splat/kindred_splat.dm
@@ -35,18 +35,15 @@
 	var/vitae_spending_rate
 	/// Which vampiric bloodline or Clan they fall into. Determines natural Disciplines. Singleton reference, never modify
 	var/datum/subsplat/vampire_clan/clan
-	/// Which morality they follow, Humanity if false and Enlightenment if true
-	var/enlightenment
 	/// The Kindred who created this Kindred, null unless Embraced in-round
 	var/mob/living/sire
 
 	/// Timer tracking how long before the Kindred can wake up from torpor
 	COOLDOWN_DECLARE(torpor_timer)
 
-/datum/splat/vampire/kindred/New(generation, clan, enlightenment = FALSE, mob/living/sire)
+/datum/splat/vampire/kindred/New(generation, clan, mob/living/sire)
 	src.generation = generation
 	src.clan = clan
-	src.enlightenment = enlightenment
 	src.sire = sire
 
 /datum/splat/vampire/kindred/on_gain()

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/kindred_splat/make_kindred.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/kindred_splat/make_kindred.dm
@@ -1,10 +1,10 @@
 /**
  * Makes the mob a Kindred with the given Generation, Clan, morality, and sire.
  */
-/mob/living/proc/make_kindred(generation = DEFAULT_GENERATION, datum/subsplat/vampire_clan/clan, enlightenment, mob/living/sire)
+/mob/living/proc/make_kindred(generation = DEFAULT_GENERATION, datum/subsplat/vampire_clan/clan, mob/living/sire)
 	RETURN_TYPE(/datum/splat/vampire/kindred)
 
-	return add_splat(/datum/splat/vampire/kindred, generation, clan, enlightenment, sire)
+	return add_splat(/datum/splat/vampire/kindred, generation, clan, sire)
 
 /**
  * Makes the mob a Kindred as if Embraced by another Kindred.
@@ -26,7 +26,7 @@
 	if (!always_same_clan && prob(5))
 		childe_clan = GLOB.vampire_clans[/datum/subsplat/vampire_clan/caitiff]
 
-	return make_kindred(sire_splat.generation + 1, childe_clan, FALSE, sire)
+	return make_kindred(sire_splat.generation + 1, childe_clan, sire)
 
 /mob/living/carbon/human/splat/kindred
 	auto_splats = list(/datum/splat/vampire/kindred)

--- a/modular_darkpack/modules/vitae/code/embracing.dm
+++ b/modular_darkpack/modules/vitae/code/embracing.dm
@@ -41,10 +41,8 @@
 			var/datum/st_stat/stat_instinct = childe.storyteller_stats[STAT_INSTINCT]
 
 			if(stat_morality_childe.morality_path.alignment == MORALITY_HUMANITY)
-				kindred_splat.enlightenment = FALSE
 				stat_morality_childe.set_score(clamp(stat_conscience.get_score(include_bonus = TRUE) + stat_self_control.get_score(include_bonus = TRUE), 0, 10))
-			else if(stat_morality_childe.morality_path.alignment == MORALITY_ENLIGHTENMENT) // just in case
-				kindred_splat.enlightenment = TRUE
+			else if(stat_morality_childe.morality_path.alignment == MORALITY_ENLIGHTENMENT) // just in case, but should be unreachable rn.
 				stat_morality_childe.set_score(clamp(stat_conviction.get_score(include_bonus = TRUE) + stat_instinct.get_score(include_bonus = TRUE), 0, 10))
 
 	addtimer(CALLBACK(childe, PROC_REF(prompt_permanent_embrace)), 1 SECONDS)

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/gifts/auspices/theurge.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/gifts/auspices/theurge.dm
@@ -106,7 +106,7 @@ the scar is received and an extra Gnosis point is spent.
 
 	var/datum/splat/vampire/kindred/kindred_splat = get_kindred_splat(target)
 	if(kindred_splat)
-		if(!kindred_splat.enlightenment)
+		if(!target.is_enlightenment())
 			. = 6
 		else if(target.st_get_stat(STAT_MORALITY) <= 7)
 			. = 6

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7609,7 +7609,6 @@
 #include "modular_darkpack\modules\storyteller_stats\code\st_stats\base_type\_attribute.dm"
 #include "modular_darkpack\modules\storyteller_stats\code\st_stats\base_type\_freebie.dm"
 #include "modular_darkpack\modules\storyteller_stats\code\st_stats\base_type\_morality.dm"
-#include "modular_darkpack\modules\storyteller_stats\code\st_stats\base_type\_path.dm"
 #include "modular_darkpack\modules\storyteller_stats\code\st_stats\base_type\_pooled.dm"
 #include "modular_darkpack\modules\storyteller_stats\code\st_stats\base_type\_virtue.dm"
 #include "modular_darkpack\modules\strings\global_strings.dm"


### PR DESCRIPTION
## About The Pull Request
Reverts DarkPack13/SecondCity#795
But we will be squashing it this time


Creates a helper proc to fetch enlightenment from the stat and removes the enlightenment var on splat.
## Why It's Good For The Game
More consistent to just directly check a datum rather then the datum having to set a var on a mob. which could be desyned if something else (like the new for kindred splat) sets it.

