### PR TITLE
Capitilized file extenstions for headshots are allowed

### DIFF
--- a/modular_darkpack/modules/flavor_text/code/preferences.dm
+++ b/modular_darkpack/modules/flavor_text/code/preferences.dm
@@ -10,7 +10,7 @@
 	///Handles the informational chat message timer.
 	COOLDOWN_DECLARE(headshot_cooldown)
 	///Assoc list of ckeys and their links, used to cut down on chat spam
-	var/list/stored_links = list()
+	var/static/list/stored_links = list()
 	var/static/link_regex = regex("files.catbox.moe|images2.imgbox.com|i.gyazo.com")
 	var/static/list/valid_extensions = list("jpg", "png", "jpeg") // Regex works fine, if you know how it works
 


### PR DESCRIPTION

## About The Pull Request
See title.
## Why It's Good For The Game
Some bum ass software will save them capitalized, current code doesnt allow those but unless im missing something they still render fine.
## Changelog
:cl:
fix: Capitilized file extenstions for headshots are allowed
/:cl:
