### PR TITLE
Finance affects roundstart money

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -216,6 +216,21 @@
 		bank_account.payday(STARTING_PAYCHECKS, free = TRUE)
 		account_id = bank_account.account_id
 		bank_account.replaceable = FALSE
+		// DARKPACK EDIT ADD - Finance affects starting money
+		if(st_get_stat(STAT_FINANCE))
+			var/finance = st_get_stat(STAT_FINANCE)
+			switch(finance)
+				if(1)
+					bank_account.account_balance = rand(800, 1200)
+				if(2)
+					bank_account.account_balance = rand(2000, 3000)
+				if(3)
+					bank_account.account_balance = rand(4000, 6000)
+				if(4)
+					bank_account.account_balance = rand(7000, 9000)
+				if(5)
+					bank_account.account_balance = rand(11000, 14000)
+		// DARKPACK EDIT ADD END - Finance affects starting money
 		add_mob_memory(/datum/memory/key/account, remembered_id = account_id)
 		add_mob_memory(/datum/memory/key/bank_pin, remembered_id = bank_account.bank_pin) // DARKPACK EDIT ADD
 


### PR DESCRIPTION
## About The Pull Request

this pr pretty simply just checks the player's finance stat immediately after job assignment and new'ing the bank account datum and sets their account balance to a range based on what their finance stat is.

gonna put a sticky note here which is probably apt - pending rework of the economy subsystem to handle paychecks and whatnot so nobody gets 14,000 at second 1 of the round and instead have a larger income, not a larger wealth. in fact, i might just work on that today, but it would require editing every job... idk...

## Why It's Good For The Game

money

## Changelog


:cl:
add: finance affects roundstart cash
/:cl:

