### PR TITLE
Fixes runtime on `auspice_rank_check()` for kinfolk

### DIFF
--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/renown.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/renown.dm
@@ -59,6 +59,8 @@
 
 
 /datum/splat/werewolf/proc/auspice_rank_check()
+	if(!auspice)
+		return RANK_CUB
 	return auspice.rank_requirments(renown)
 
 // Pretty iffy on this. This could likely just be moved onto the splat itself so corax and other breeds can override it.


### PR DESCRIPTION

## About The Pull Request
Kinfolk wont try to access a auspice they dont have when checking rank
## Why It's Good For The Game
runtime bad.
## Changelog
:cl:
code: Fixes runtime from kinfolk not having an auspice to check when deciding rank. They default to a cub.
/:cl:
