### PR TITLE
Retail stores have dollars in front

### DIFF
--- a/modular_darkpack/modules/retail/code/_retail.dm
+++ b/modular_darkpack/modules/retail/code/_retail.dm
@@ -95,6 +95,7 @@
 		)
 			product_data["icon"] = initial(printed.icon)
 			product_data["icon_state"] = initial(printed.icon_state)
+	.["money_symbol"] = MONEY_SYMBOL
 
 /obj/structure/retail/ui_data(mob/user)
 	. = list()

--- a/tgui/packages/tgui/interfaces/RetailVendor.jsx
+++ b/tgui/packages/tgui/interfaces/RetailVendor.jsx
@@ -75,7 +75,7 @@ export const RetailVendor = (props) => {
                             data.user.is_card === 0) ||
                           product.stock === 0
                         }
-                        content={`${product.price}$`}
+                        content={`${data.money_symbol}${product.price}`}
                         onClick={() =>
                           act('purchase', {
                             ref: product.ref,


### PR DESCRIPTION

## About The Pull Request
Noticed this change from https://github.com/The-Final-Nights/The-Final-Nights-Rebase/pull/101

did it using the currency define as its used for vendors and most other code (thanks to some tg prs i made)
## Why It's Good For The Game
Grammer or somethin
## Changelog
:cl:
spellcheck: $ symbol appears before the cash value for stores
/:cl:
