### PR TITLE
Mapped glowshrooms are lazy

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -116,7 +116,10 @@ GLOBAL_VAR_INIT(glowshrooms, 0)
 	AddElement(/datum/element/atmos_sensitive, mapload)
 	COOLDOWN_START(src, spread_cooldown, rand(min_delay_spread, max_delay_spread))
 
-	START_PROCESSING(SSobj, src)
+	// DARKPACK EDIT CHANGE START
+	if(!mapload)
+		START_PROCESSING(SSobj, src)
+	// DARKPACK EDIT CHANGE END
 
 	var/static/list/hovering_item_typechecks = list(
 		/obj/item/plant_analyzer = list(


### PR DESCRIPTION

## About The Pull Request
Minor atomization from https://github.com/ApocryphaXIII/Apocrypha13/pull/28
## Why It's Good For The Game
There is a few variants that dont have this behavior and pretty much no mapper expects them to spread. Prevents them from randomly dying.
## Changelog
:cl:
map: mapped glowshrooms no longer spread around
/:cl:
