### PR TITLE
Gangrel claws no longer have armor penetration or block chance

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/protean/claws.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/claws.dm
@@ -9,8 +9,6 @@
 	force = 1 TTRPG_DAMAGE
 	damtype = AGGRAVATED // Based on V20
 	sharpness = SHARP_POINTY
-	armour_penetration = 40
-	block_chance = 20
 	item_flags = DROPDEL
 	masquerade_violating = TRUE
 	obj_flags = NONE


### PR DESCRIPTION

## About The Pull Request

see title
## Why It's Good For The Game

this shit does 60 straight aggravated damage with 5 strength and if you were to use city gangrel you'd get to use celerity out of the box too and spam 60 aggravated damage with crazy high armor pen and giganuke people
## Changelog
:cl:
balance: Gangrel claws no longer have armor penetration or block chance
/:cl:
