### PR TITLE
fixes umbra parallax

### DIFF
--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -261,6 +261,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_home)
 			return new /atom/movable/screen/parallax_layer/layer_1(null, null, owner)
 		if(2)
 			return new /atom/movable/screen/parallax_layer/layer_2(null, null, owner)
+		/* // DARKPACK EDIT REMOVAL START
 		if(3)
 			return new /atom/movable/screen/parallax_layer/planet(null, null, owner)
 		if(4)
@@ -271,11 +272,14 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_home)
 		if(5)
 			if(SSparallax.random_layer)
 				return new /atom/movable/screen/parallax_layer/layer_3(null, null, owner)
+		*/ // DARKPACK EDIT REMOVAL END
 
 /atom/movable/screen/parallax_home/proc/regenerate_layers()
 	clear_layers()
 	if(layers_to_draw == 0 && !draw_old_space)
 		return
+
+	layers_to_draw = min(layers_to_draw, 2) // DARKPACK EDIT ADD - (Sorry but we only have 2...)
 
 	parallax_layers_cached = list()
 	for(var/space_layer in 1 to layers_to_draw)
@@ -283,6 +287,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_home)
 
 	if(draw_old_space)
 		parallax_layers_cached += new /atom/movable/screen/parallax_layer/old(null, null, owner)
+
+	parallax_layers_cached += new /atom/movable/screen/parallax_layer/umbra(null, null, owner) // DARKPACK EDIT ADD - UMBRA
 
 	display_layers()
 

--- a/modular_darkpack/modules/umbra/code/parallax.dm
+++ b/modular_darkpack/modules/umbra/code/parallax.dm
@@ -5,17 +5,16 @@
 	speed = 0.6
 	layer = 3
 
-/atom/movable/screen/parallax_layer/umbra/Initialize(mapload, datum/hud/hud_owner)
+/atom/movable/screen/parallax_layer/umbra/Initialize(mapload, datum/hud/hud_owner, client/owner)
 	. = ..()
-	var/client/boss = hud_owner?.mymob?.canon_client
-	if(!boss)
+	if(!owner)
 		return
 	var/static/list/connections = list(
 		COMSIG_MOVABLE_Z_CHANGED = PROC_REF(on_z_change),
 		COMSIG_MOB_LOGOUT = PROC_REF(on_mob_logout),
 	)
-	AddComponent(/datum/component/connect_mob_behalf, boss, connections)
-	on_z_change(hud_owner?.mymob)
+	AddComponent(/datum/component/connect_mob_behalf, owner, connections)
+	on_z_change(owner.mob)
 
 /atom/movable/screen/parallax_layer/umbra/proc/on_mob_logout(mob/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Fixed and updated/reintroduced to the new code.
## Why It's Good For The Game
A bad conflict resolution in either #755 or #803 broke the umbra parallax and reintroduced parallaxes that our icon file has nothing for.
## Changelog
:cl:
fix: The umbra should now have its parallax again
/:cl:
