### PR TITLE
Library sells art supplies now!

### DIFF
--- a/modular_darkpack/modules/retail/code/stores/library.dm
+++ b/modular_darkpack/modules/retail/code/stores/library.dm
@@ -1,10 +1,10 @@
 /obj/structure/retail/library
 	products_list = list(
-		new /datum/data/vending_product("black pen",	/obj/item/pen,  5),
-		new /datum/data/vending_product("folder",	/obj/item/folder,  5),
-		new /datum/data/vending_product("four-color pen",	/obj/item/pen/fourcolor,  10),
+		new /datum/data/vending_product("black pen", /obj/item/pen, 5),
+		new /datum/data/vending_product("folder", /obj/item/folder, 5),
+		new /datum/data/vending_product("four-color pen", /obj/item/pen/fourcolor, 10),
 		new /datum/data/vending_product("box of crayons", /obj/item/storage/crayons, 10),
-		new /datum/data/vending_product("fountain pen",	/obj/item/pen/fountain,  15),
+		new /datum/data/vending_product("fountain pen", /obj/item/pen/fountain, 15),
 		new /datum/data/vending_product("canvas (19x19)", /obj/item/canvas/nineteen_nineteen, 19),
 		new /datum/data/vending_product("canvas (23x19)", /obj/item/canvas/twentythree_nineteen, 23),
 		new /datum/data/vending_product("canvas (23x23)", /obj/item/canvas/twentythree_twentythree, 23),
@@ -13,8 +13,8 @@
 		new /datum/data/vending_product("canvas (45x27)", /obj/item/canvas/fortyfive_twentyseven, 45),
 		new /datum/data/vending_product("paper bin", /obj/item/paper_bin, 20),
 		new /datum/data/vending_product("paint palette", /obj/item/paint_palette, 20),
-		new /datum/data/vending_product("Bible",	/obj/item/book/bible,  20),
-		new /datum/data/vending_product("Quran",	/obj/item/vampirebook/quran,  20),
+		new /datum/data/vending_product("Bible", /obj/item/book/bible, 20),
+		new /datum/data/vending_product("Quran", /obj/item/vampirebook/quran, 20),
 		new /datum/data/vending_product("spray paint", /obj/item/toy/crayon/spraycan, 25),
 		new /datum/data/vending_product("newspaper", /obj/item/newspaper, 5)
 	)


### PR DESCRIPTION
## About The Pull Request
Ultra-quick PR to add some more art supplies to the library, canvases for painting and paperbins for paperwork.

## Why It's Good For The Game

It's nice for the playerbase to have some more supplies to make stuff, canvases can't be bought anywhere else as far as I am aware and the library selling paper helps for paperwork instead of going to the warehouse to buy a giant crate.

<img width="353" height="552" alt="image" src="https://github.com/user-attachments/assets/438c2f9e-d035-4933-b9f6-f628e3cf2c68" />


## Changelog

:cl:
add: adds canvases and paper to the library shop
/:cl:
