### PR TITLE
mummywrap fetish changes

### DIFF
--- a/modular_darkpack/modules/occult_artifacts/code/artifacts/mummywrap_fetish.dm
+++ b/modular_darkpack/modules/occult_artifacts/code/artifacts/mummywrap_fetish.dm
@@ -10,5 +10,4 @@
 	if(identified && owner)
 		if(last_regen+60 < world.time)
 			last_regen = world.time
-			owner.adjust_brute_loss(-5)
-			owner.adjust_fire_loss(-5)
+			owner.heal_storyteller_health(dots_to_heal = 1, heal_aggravated = FALSE, heal_scars = TRUE, heal_blood = TRUE)


### PR DESCRIPTION

## About The Pull Request
Changing the mummywrap fetish behaviour to use fallcon's storyteller healing system, rather than flatly healing 
burn/brute
## Why It's Good For The Game
Moving towards the more lore-accurate system of healing is good, i think.
## Changelog
Changed the way that mummywrap fetish regens health, making it use a "dot" to heal different things each time
:cl:
balance: somewhat buffs the capabilities of the fetish, by making it able to heal wounds, comment if that's too strong.
:cl:
