### PR TITLE
Stairs layer correct

### DIFF
--- a/modular_darkpack/master_files/code/game/objects/structures/stairs.dm
+++ b/modular_darkpack/master_files/code/game/objects/structures/stairs.dm
@@ -1,3 +1,7 @@
+/obj/structure/stairs
+	plane = GAME_PLANE
+	layer = ABOVE_NORMAL_TURF_LAYER
+
 /obj/structure/stairs/ramp
 	name = "ramp"
 	icon = 'modular_darkpack/modules/walls/icons/floors.dmi'


### PR DESCRIPTION

## About The Pull Request
Basically just reverts them to there old layer to prevent this.

<img width="435" height="250" alt="image" src="https://github.com/user-attachments/assets/0abedb1c-a559-4482-876d-8867f1c3d0bf" />

## Why It's Good For The Game
This was bad...

TG does not assume they are tall or anything but a flat turf.

## Changelog
:cl:
fix: Stairs now layer properly
/:cl:
