### PR TITLE
Dominate Gives Feedback & V20 Adjustment

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/dominate/dominate.dm
+++ b/modular_darkpack/modules/powers/code/discipline/dominate/dominate.dm
@@ -218,6 +218,7 @@
 		return TRUE
 
 	to_chat(owner, span_warning("[target] has resisted your domination!"))
+	to_chat(target, span_warning("[user] intensely stares at you."))
 	do_cooldown(TRUE)
 	return FALSE
 
@@ -264,6 +265,10 @@
 		pulse_interval = successes
 		return TRUE
 	pulse_interval = 0
+
+	to_chat(owner, span_warning("[target] has resisted your domination!"))
+	to_chat(target, span_warning("[user] intensely stares at you."))
+
 	do_cooldown(cooldown_length)
 	return FALSE
 
@@ -373,18 +378,15 @@
 /datum/discipline_power/dominate/the_forgetful_mind/proc/get_success_message(successes)
 	switch(successes)
 		if(1)
-			return "a single memory is removed, and no alteration takes its place, leaving a void for the true memory to bubble up with the right circumstances"
+			return "a single memory is permanently removed, and no alteration takes its place, leaving a void for the true memory to bubble up with the right circumstances"
 		if(2)
 			return "multiple memories may be permanently removed, but not altered, leaving a void for the true memories to potentially re-emerge with intense recollection"
 		if(3)
 			return "multiple memories may be permanently altered or removed, but without careful and precise alteration, the true memories may crawl forth much later"
 		if(4)
 			return "deep and intense alterations or removals may take place in the memory, changing entire events or conversations with great strength"
-		if(5)
-			return "entire periods of life and personality may be removed, altered or otherwise as the subconcious completely collapses"
-		if(6 to INFINITY)
-			return "there is no limit to the extent to which the memories may be affected, forever changing the memory beyond recognition. There is no hope."
-
+		if(5 to INFINITY)
+			return "entire periods of life may be completely restructured or otherwise as the subconcious completely collapses"
 
 /datum/discipline_power/dominate/the_forgetful_mind/pre_activation_checks(mob/living/carbon/human/target)
 
@@ -397,6 +399,7 @@
 			return FALSE
 		return TRUE
 	to_chat(owner, span_warning("[target] has resisted your domination!"))
+	to_chat(target, span_warning("[user] intensely stares at you."))
 	do_cooldown(cooldown_length)
 	return FALSE
 
@@ -471,6 +474,7 @@
 	var/roll_success = dominate_check(owner, target, owner.st_get_stat(STAT_CHARISMA) + owner.st_get_stat(STAT_INTIMIDATION))
 	if(!roll_success)
 		to_chat(owner, span_warning("[target] has resisted your domination!"))
+		to_chat(target, span_warning("[user] intensely stares at you."))
 		do_cooldown(cooldown_length)
 	return roll_success
 

--- a/modular_darkpack/modules/powers/code/discipline/dominate/dominate.dm
+++ b/modular_darkpack/modules/powers/code/discipline/dominate/dominate.dm
@@ -202,11 +202,14 @@
 			return "immediate and vigorous completion"
 
 /datum/discipline_power/dominate/command/pre_activation_checks(mob/living/carbon/human/target)
+
+	custom_command = tgui_input_text(owner, "Dominate Command", "What is your command?", encode = FALSE)
+	owner.say(custom_command)
+
 	successes = dominate_check(owner, target, owner.st_get_stat(STAT_MANIPULATION) + owner.st_get_stat(STAT_INTIMIDATION), numerical = TRUE)
 	if(successes > 0)
 		var/command_strength = get_success_message(successes)
 		to_chat(owner, span_notice("You have the power to Command your target with [command_strength]!"))
-		custom_command = tgui_input_text(owner, "Dominate Command", "What is your command?", encode = FALSE)
 		var/mob/living/carbon/human/conditioner = target.conditioner?.resolve()
 		if(owner != conditioner)
 			//V20 Dominate 'Command' section
@@ -218,7 +221,7 @@
 		return TRUE
 
 	to_chat(owner, span_warning("[target] has resisted your domination!"))
-	to_chat(target, span_warning("[user] intensely stares at you."))
+	to_chat(target, span_warning("[owner] intensely stares at you."))
 	do_cooldown(TRUE)
 	return FALSE
 
@@ -226,7 +229,6 @@
 	. = ..()
 	to_chat(owner, span_warning("You've successfully dominated [target]'s mind!"))
 	log_combat(owner, target, "Dominated with Command: [custom_command]")
-	owner.say(custom_command)
 	to_chat(target, span_big("[custom_command]"))
 	var/command_strength = get_success_message(successes)
 	to_chat(target, span_warning("[owner] has successfully dominated your mind with [successes] successes. You feel compelled to [custom_command] with [command_strength]."))
@@ -267,7 +269,7 @@
 	pulse_interval = 0
 
 	to_chat(owner, span_warning("[target] has resisted your domination!"))
-	to_chat(target, span_warning("[user] intensely stares at you."))
+	to_chat(target, span_warning("[owner] intensely stares at you."))
 
 	do_cooldown(cooldown_length)
 	return FALSE
@@ -399,7 +401,7 @@
 			return FALSE
 		return TRUE
 	to_chat(owner, span_warning("[target] has resisted your domination!"))
-	to_chat(target, span_warning("[user] intensely stares at you."))
+	to_chat(target, span_warning("[owner] intensely stares at you."))
 	do_cooldown(cooldown_length)
 	return FALSE
 
@@ -474,7 +476,7 @@
 	var/roll_success = dominate_check(owner, target, owner.st_get_stat(STAT_CHARISMA) + owner.st_get_stat(STAT_INTIMIDATION))
 	if(!roll_success)
 		to_chat(owner, span_warning("[target] has resisted your domination!"))
-		to_chat(target, span_warning("[user] intensely stares at you."))
+		to_chat(target, span_warning("[owner] intensely stares at you."))
 		do_cooldown(cooldown_length)
 	return roll_success
 


### PR DESCRIPTION

## About The Pull Request

This does a few minor things to dominate, took the writing premise off of https://github.com/DarkPack13/SecondCity/pull/873 as well as a few changes to failure messages.

Dominate is an overt power that is noticeable to an observant kindred/ghoul due to needed eye contact, even without the uttering of a command. (This may make sense to do maybe a perception check but I saw no checks needed in rules or when asking people who've run tabletop sessions of it. So keeping it as is for now I guess.)

Furthermore certain stuff like mesmerize wouldn't give a fail message, so if you don't have the chat window rolls you may not realize it. Now it's more obvious to failed the mesmerize.

Moved the order around where you input your command before you roll rather than after. Seems to match how it's supposed to work on TT as you would state what you want to say and roll at the same time; not roll then choose what you want to say.
<img width="457" height="174" alt="image" src="https://github.com/user-attachments/assets/2fa7ebb0-10b9-4456-a871-3921241b4052" />

Also, as on the other PR, removed 6 success roll to forgetful mind as that is not a V20 mechanic, updated the wording of 5 - as personality changing is a Conditioning thing more than a memory thing, and added 'permeant' to dom 1 to be in line with the other dominates.

## Why It's Good For The Game

Mainly does three things. 
1. More V20 accuracy to how the abilities work
2. Provides feedback on failure to both the user (such as on mesmerize) and the target (who, if kindred/ghoul, may know)
3. Solidifies dominate as an overt, but not masq breaching, action.

## Changelog
:cl:
add: Added failure messages to target and caster (if not present already) when failing a dominate roll.
del: Removed Dom 3's 6 success roll.
spellcheck: Not much of an actual spellcheck - reworded description of Dom 1 and 5 to be accurate to V20.
/:cl:
