### PR TITLE
supervisor fixes

### DIFF
--- a/modular_darkpack/modules/jobs/code/clinic/director.dm
+++ b/modular_darkpack/modules/jobs/code/clinic/director.dm
@@ -3,7 +3,7 @@
 	faction = FACTION_CITY
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Camarilla or the Anarchs"
+	supervisors = "the Hospital Administrator"
 	exp_required_type_department = EXP_TYPE_CLINIC
 	config_tag = "CLINIC_DIRECTOR"
 	outfit = /datum/outfit/job/vampire/clinic_director

--- a/modular_darkpack/modules/jobs/code/clinic/doctor.dm
+++ b/modular_darkpack/modules/jobs/code/clinic/doctor.dm
@@ -3,7 +3,7 @@
 	faction = FACTION_CITY
 	total_positions = 4
 	spawn_positions = 4
-	supervisors = "the Camarilla or the Anarchs"
+	supervisors = "the Clinic Director"
 	exp_required_type_department = EXP_TYPE_CLINIC
 	config_tag = "DOCTOR"
 	job_flags = CITY_JOB_FLAGS

--- a/modular_darkpack/modules/jobs/code/miscelllaneous/club_worker.dm
+++ b/modular_darkpack/modules/jobs/code/miscelllaneous/club_worker.dm
@@ -3,7 +3,7 @@
 	faction = FACTION_CITY
 	total_positions = 4
 	spawn_positions = 4
-	supervisors = /datum/job/vampire/primogen_toreador
+	supervisors = "Rosebud Night Club Owner"
 	job_flags = CITY_JOB_FLAGS
 	outfit = /datum/outfit/job/vampire/club_worker
 	config_tag = "CLUB_WORKER"

--- a/modular_darkpack/modules/jobs/code/miscelllaneous/priest.dm
+++ b/modular_darkpack/modules/jobs/code/miscelllaneous/priest.dm
@@ -3,7 +3,7 @@
 	faction = FACTION_CITY
 	total_positions = 2
 	spawn_positions = 2
-	supervisors = "God"
+	supervisors = "your faith"
 	config_tag = "PRIEST"
 	outfit = /datum/outfit/job/vampire/priest
 	job_flags = CITY_JOB_FLAGS

--- a/modular_darkpack/modules/jobs/code/miscelllaneous/taxi.dm
+++ b/modular_darkpack/modules/jobs/code/miscelllaneous/taxi.dm
@@ -3,7 +3,7 @@
 	faction = FACTION_CITY
 	total_positions = 3
 	spawn_positions = 3
-	supervisors = SUPERVISOR_TRADITIONS
+	supervisors = "your cab service"
 	job_flags = CITY_JOB_FLAGS
 	outfit = /datum/outfit/job/vampire/taxi
 	config_tag = "TAXI_DRIVER"

--- a/modular_darkpack/modules/jobs/code/police/captain.dm
+++ b/modular_darkpack/modules/jobs/code/police/captain.dm
@@ -3,7 +3,7 @@
 	faction = FACTION_CITY
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = " the SFPD Chief"
+	supervisors = "the SFPD Chief"
 	config_tag = "POLICE_CAPTAIN"
 	outfit = /datum/outfit/job/vampire/police_captain
 	job_flags = CITY_JOB_FLAGS


### PR DESCRIPTION

## About The Pull Request
why are human doctors serving the camarilla
club workers are being told they serve the Primogen Toreador
## Why It's Good For The Game
human doctors should not know the camarilla
## Changelog
:cl:
fix: Doctors, Clinic Directors, Strippers, and Taxi Drivers no longer inherently serve the Camarilla.
/:cl:
