### PR TITLE
Aura Perception Rolls and a Pale Aura Fix

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/auspex/aura_component.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/aura_component.dm
@@ -156,7 +156,7 @@
 		examine_message += "Black veins pulse through [parent_mob.p_their()] aura."
 	if(HAS_TRAIT(parent_mob, TRAIT_FRENETIC_AURA))
 		examine_message += "[parent_mob.p_Their()] aura appears especially energetic."
-	if(get_ghoul_splat(parent_mob))
+	if(!HAS_TRAIT(parent, TRAIT_PALE_AURA) && get_ghoul_splat(parent_mob))
 		examine_message += "Pale blotches mark [parent_mob.p_their()] aura."
 	if(get_kindred_splat(parent_mob))
 		var/mob/living/carbon/human/lick = parent_mob

--- a/modular_darkpack/modules/powers/code/discipline/auspex/auspex.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/auspex.dm
@@ -102,6 +102,7 @@
 
 
 /datum/storyteller_roll/aura_perception
+	bumper_text = "aura reading"
 	difficulty = 8
 	applicable_stats = list(STAT_PERCEPTION, STAT_EMPATHY)
 	numerical = TRUE

--- a/modular_darkpack/modules/powers/code/discipline/auspex/auspex.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/auspex.dm
@@ -51,7 +51,6 @@
 	if(SENSE_VISION in output_senses)
 		owner.client?.view_size?.setTo(2) // This increases the view size of the player by 2 tiles in each direction. I dont know why it's called Set if it Adds.
 		ADD_TRAIT(owner, TRAIT_REFLECTIVE_EYES, DISCIPLINE_TRAIT(type))
-		ADD_TRAIT(owner, TRAIT_MINOR_NIGHT_VISION, DISCIPLINE_TRAIT(type))
 		var/obj/item/organ/eyes/kindred_eyes = owner.get_organ_slot(ORGAN_SLOT_EYES)
 		if(kindred_eyes)
 			kindred_eyes.flash_protect = max(kindred_eyes.flash_protect += -2, FLASH_PROTECTION_HYPER_SENSITIVE)
@@ -82,7 +81,6 @@
 	// Vision
 	owner.client?.view_size?.resetToDefault()
 	REMOVE_TRAIT(owner, TRAIT_REFLECTIVE_EYES, DISCIPLINE_TRAIT(type))
-	REMOVE_TRAIT(owner, TRAIT_MINOR_NIGHT_VISION, DISCIPLINE_TRAIT(type))
 	var/obj/item/organ/eyes/kindred_eyes = owner.get_organ_slot(ORGAN_SLOT_EYES)
 	if(kindred_eyes)
 		kindred_eyes.flash_protect = max(kindred_eyes.flash_protect += 2, FLASH_PROTECTION_NONE)

--- a/modular_darkpack/modules/powers/code/discipline/auspex/auspex.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/auspex.dm
@@ -51,6 +51,7 @@
 	if(SENSE_VISION in output_senses)
 		owner.client?.view_size?.setTo(2) // This increases the view size of the player by 2 tiles in each direction. I dont know why it's called Set if it Adds.
 		ADD_TRAIT(owner, TRAIT_REFLECTIVE_EYES, DISCIPLINE_TRAIT(type))
+		ADD_TRAIT(owner, TRAIT_MINOR_NIGHT_VISION, DISCIPLINE_TRAIT(type))
 		var/obj/item/organ/eyes/kindred_eyes = owner.get_organ_slot(ORGAN_SLOT_EYES)
 		if(kindred_eyes)
 			kindred_eyes.flash_protect = max(kindred_eyes.flash_protect += -2, FLASH_PROTECTION_HYPER_SENSITIVE)
@@ -81,6 +82,7 @@
 	// Vision
 	owner.client?.view_size?.resetToDefault()
 	REMOVE_TRAIT(owner, TRAIT_REFLECTIVE_EYES, DISCIPLINE_TRAIT(type))
+	REMOVE_TRAIT(owner, TRAIT_MINOR_NIGHT_VISION, DISCIPLINE_TRAIT(type))
 	var/obj/item/organ/eyes/kindred_eyes = owner.get_organ_slot(ORGAN_SLOT_EYES)
 	if(kindred_eyes)
 		kindred_eyes.flash_protect = max(kindred_eyes.flash_protect += 2, FLASH_PROTECTION_NONE)
@@ -98,6 +100,13 @@
 	INVOKE_ASYNC(owner, TYPE_PROC_REF(/mob, emote), "shiver", forced = TRUE)
 	owner.Stun(0.5 SECONDS)
 
+
+/datum/storyteller_roll/aura_perception
+	difficulty = 8
+	applicable_stats = list(STAT_PERCEPTION, STAT_EMPATHY)
+	numerical = TRUE
+	roll_output_type = ROLL_PRIVATE
+
 //AURA PERCEPTION
 /datum/discipline_power/auspex/aura_perception
 	name = "Aura Perception"
@@ -110,6 +119,18 @@
 	vitae_cost = 0
 
 	toggled = TRUE
+	var/datum/storyteller_roll/aura_perception/aura_roll
+
+/datum/discipline_power/auspex/aura_perception/pre_activation_checks(mob/living/target)
+	. = ..()
+	if(!aura_roll)
+		aura_roll = new()
+	switch(aura_roll.st_roll(owner, target))
+		if(ROLL_SUCCESS)
+			return TRUE
+		else
+			to_chat(span_danger("You fail to read into anything at all..."))
+			return FALSE
 
 /datum/discipline_power/auspex/aura_perception/activate()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Aura Perception now rolls Perception and Empathy against difficulty 8.
Pale Aura no longer shows pale splotches when used by Ghouls.
## Why It's Good For The Game
Aura Perception rolls are using a simplified version for crowds - simple 'success is success, failure is failure.'
<img width="519" height="284" alt="image" src="https://github.com/user-attachments/assets/b16bf8f0-5173-472e-ab49-e5f3a8030903" />
<img width="542" height="365" alt="image" src="https://github.com/user-attachments/assets/64750cb3-845e-4b61-8114-fa0b80d10a29" />

Pale Aura is supposed to disguise oneself as a Kindred, so it felt a bit silly to have it still give the 'this is a ghoul!' description. And how do you have pale splotches if it's already pale?

## Changelog
:cl:
balance: Aura Perception now rolls for success. Perception and Empathy against difficulty 8.
fix: Pale Aura now properly disguises Ghouls as Kindred.
/:cl:
