### PR TITLE
Changes Exploitable Records text to match Eyes of Chaos

### DIFF
--- a/code/__DEFINES/~darkpack/flavor_text.dm
+++ b/code/__DEFINES/~darkpack/flavor_text.dm
@@ -14,4 +14,4 @@
 /// How many characters will be displayed in the flavor text preview before we cut it off?
 #define FLAVOR_PREVIEW_LIMIT 110
 /// The default value that will go in any new player's exploitables.
-#define EXPLOITABLE_DEFAULT_TEXT "This is where you put flaws that can be exploited in any way. This will be viewable by certain discplines if you modify this string, but only if there's anything at all in this box."
+#define EXPLOITABLE_DEFAULT_TEXT "You should put any exploitable information here, but not as simple facts; imagery and allegory invoking your weaknesses rather than literal statements is preferred, due to the abilities that access this. They will only access this if you modify this text."

--- a/code/__DEFINES/~darkpack/savefile.dm
+++ b/code/__DEFINES/~darkpack/savefile.dm
@@ -1,4 +1,4 @@
 #define SAVEFILE_DARKPACK_VERSION_MIN 0 // 0 would mean this was a sheet before versioning in theory
-#define SAVEFILE_DARKPACK_VERSION_MAX 2
+#define SAVEFILE_DARKPACK_VERSION_MAX 3
 
 #define SHOULD_UPDATE_DATA_DARKPACK(version) (version >= SAVE_DATA_NO_ERROR && version < SAVEFILE_DARKPACK_VERSION_MAX)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -189,6 +189,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if (current_version < 2)
 		if(read_preference(/datum/preference/choiced/subsplat/garou_breed) == "Metis")
 			write_preference(GLOB.preference_entries[/datum/preference/choiced/subsplat/garou_breed], BREED_CRINOS)
+	if (current_version < 3)
+		if(read_preference(/datum/preference/text/exploitable) == "This is where you put flaws that can be exploited in any way. This will be viewable by certain discplines if you modify this string, but only if there's anything at all in this box.")
+			write_preference(GLOB.preference_entries[/datum/preference/text/exploitable], EXPLOITABLE_DEFAULT_TEXT)
 // DARKPACK EDIT ADD END
 
 /// checks through keybindings for outdated unbound keys and updates them


### PR DESCRIPTION

## About The Pull Request

Changed the exploitable records default text to more accurately describe how Eyes of Chaos reveals information.

<img width="557" height="686" alt="image" src="https://github.com/user-attachments/assets/a370d951-a756-4ff5-9c48-133c6e925eba" />


## Why It's Good For The Game

A lot of people on TFN seemed confused by Eyes of Chaos so I figured this would at least help clear it up a bit.

## Changelog
:cl:
spellcheck: Exploitable records description now more accurately describes the intended contents.
/:cl:
