### PR TITLE
V20 Path Parity

### DIFF
--- a/code/__DEFINES/~darkpack/morality_defines.dm
+++ b/code/__DEFINES/~darkpack/morality_defines.dm
@@ -25,6 +25,12 @@
 #define BEARING_GUILT (1<<11)
 #define BEARING_TRIBULATION (1<<12)
 #define BEARING_SEDUCTION (1<<13)
+#define BEARING_BALANCE (1<<14)
+#define BEARING_CONFIDENCE (1<<15)
+#define BEARING_CORRUPTION (1<<16)
+#define BEARING_DARKNESS (1<<17)
+#define BEARING_FURY (1<<18)
+#define BEARING_RAPTURE (1<<19)
 
 // Path hits
 #define PATH_SCORE_DOWN -1

--- a/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/paths.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/paths.dm
@@ -183,9 +183,3 @@
 	desc = "The Internalists of the Path of Self-Focus would find inaction and acceptance to be their code; they do not worry about what is or what is to be, they worry only about the now. They feed and kill when they need, yet find themselves considered slow and passive by most. A charitable observer may call them perceptive and introspective."
 	alignment = MORALITY_ENLIGHTENMENT
 	bearing = BEARING_BALANCE
-
-/datum/morality/assaku
-	name = "Path of Asakku"
-	desc = "Not truly a Path, Asakku represents a Kindred who has fallen to Vicissitude's pollution. This journey can begin either consciously or unconsciously, but the result is to be irrevocably altered - one cannot abandon this Path once it has been taken. Less a belief system and more a state of being, the Corrupted seek to spread Vicissitude as widely as possible; either by teaching it, crafting others with it, or destroying those who refuse it."
-	alignment = MORALITY_ENLIGHTENMENT
-	bearing = BEARING_CORRUPTION

--- a/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/paths.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/paths.dm
@@ -133,7 +133,7 @@
 	bearing = BEARING_TRIBULATION // add this
 
 /datum/morality/lilith/seed
-	name = "Path of the Serepent's Seed"
+	name = "Path of the Serpent's Seed"
 	desc = "A variant of Bahari beliefs, adherents of this prefer a much softer touch; to defeat Caine, they have no intent of destruction, they would much prefer to subvert the Noddists and bury his legacy."
 
 /datum/morality/lilith/midwives

--- a/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/paths.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/paths.dm
@@ -32,7 +32,7 @@
 
 /datum/morality/assamite
 	name = "Path of Blood"
-	desc = "The Path of Blood is a Path of Enlightenment common among the Assamites. Its followers fight the Beast with rigorous devotion to the cause of Haqim. Adherents are called Dervishes or Assassins."
+	desc = "The Path of Blood is a Path of Enlightenment found almost exclusively among the Banu Haqim. Its followers fight the Beast with rigorous devotion to the cause of their founder. Adherents are called Dervishes."
 	alignment = MORALITY_ENLIGHTENMENT
 	bearing = BEARING_RESOLVE
 
@@ -60,13 +60,33 @@
 	alignment = MORALITY_ENLIGHTENMENT
 	bearing = BEARING_DEVOTION
 
+/datum/morality/typhon/ecstasy
+	name = "Path of Ecstasy"
+	desc = "The Path of Ecstasy is intimately tied to a variant of Setite doctrine, finding the act of reveling in euphoria to itself be holy. Ecstatics stuff the beast full of pleasure to render it fat and lazy, and vary from the Typhonists in focusing upon the pleasures rather than the corruption itself."
+	bearing = BEARING_RAPTURE
+
+/datum/morality/typhon/warrior
+	name = "Path of the Warrior"
+	desc = "The Setites of this Path do not corrupt from the shadows, but embody their ideal of Set as a warrior. They consider their fanaticism and masochism to itself be their holy acts, fighting a war to intimidate even the Beast itself with their prowess."
+	bearing = BEARING_FURY
+
 /datum/morality/bones
-	name = "Path of Bones"
-	desc = "The Path of Bones, whose followers are often called Gravediggers, is a Path of Enlightenment that suppresses the Beast by studying the true nature of death and its relationships with other states of existence. Scholars of death and the transition into it, followers of this Path benefit Necromantic and Thanatological study via the knowledge they bring, rather than the political or pragmatic benefits of their concourse with the dead. This Path is sometimes derided as one that celebrates wanton murder, but the Gravedigger's curiosity supercedes their concern for life - and their encounters with all manner of mortality can be made victim of their grim curiosity, causing them to rarely deal with mortals, resulting in a very introverted, quiet temperament."
+	name = "Path of the Bones"
+	desc = "The Path of the Bones, whose followers are nicknamed Gravediggers, is a Path of Enlightenment that suppresses the Beast by studying the true nature of death and its relationships with other states of existence. Scholars of death and the transition into it, followers of this Path benefit Necromantic and Thanatological study via the knowledge they bring, rather than the political or pragmatic benefits of their concourse with the dead. This Path is sometimes derided as one that celebrates wanton murder, but the Gravedigger's curiosity supercedes their concern for life - and their encounters with all manner of mortality can be made victim of their grim curiosity, causing them to rarely deal with mortals, resulting in a very introverted, quiet temperament."
 	alignment = MORALITY_ENLIGHTENMENT
 	bearing = BEARING_SILENCE
 
+/datum/morality/bones/death
+	name = "Path of Death and the Soul"
+	desc = "A path oft-considered 'inspired by' the Path of the Bones when charitable and 'stolen from' the Path when discharitable, it holds many of the same tenets but would be found more commonly amongst the Sabbat. Its adherents claim a distinct nature, but outsiders have yet to identify these distictions."
+
 /datum/morality/night
+	name = "Path of Night"
+	desc = "Those who follow this path accept that the Embrace has damned them; and they will not be damned alone. Found largely among the younger Lasombra, the purpose of this path is simply to act as an agent of evil and fulfill your sinful nature."
+	alignment = MORALITY_ENLIGHTENMENT
+	bearing = BEARING_DARKNESS
+
+/datum/morality/night/road
 	name = "Road of Night"
 	desc = "Via Noctis, commonly called the Road of Night. The Redeemers feel the weight of Caine's curse and their own damnation, even more so than those who follow Via Caeli. Also like the Faithful, the Redeemers seek redemption and forgiveness, and to earn it requires suffering and purification. However, instead of the fairly benign ways of the Faithful, the Redeemers actively go about the world of man, punishing and killing mortal sinners. Some followers of Via Noctis offer penance for lesser deeds, and still others will Embrace irredeemable mortals to help them in their punishment. They also target Cainites who would tempt mortals into corruption, outstanding examples being the Followers of Set and the Baali."
 	alignment = MORALITY_ENLIGHTENMENT
@@ -83,6 +103,10 @@
 	desc = "The Path of the Feral Heart (sometimes called the 'Path of the Beast') is a Path of Enlightenment practiced especially by members of Clan Gangrel. It controls the Beast by accepting its urges as natural and accepting their role as a hunter among hunters. Adherents are called Bestials or Beasts."
 	alignment = MORALITY_ENLIGHTENMENT
 	bearing = BEARING_MENACE
+
+/datum/morality/beast/harmony
+	name = "Path of Harmony"
+	desc = "A similar path to that of the Feral Heart, this is often considered a more ancient variant. While a Harmonist feels much the same regarding their role as a predator, they contextualize themself further with their role in the natural world and tend to have greater Conscience."
 
 /datum/morality/samiel
 	name = "Code of Samiel"
@@ -108,6 +132,22 @@
 	alignment = MORALITY_ENLIGHTENMENT
 	bearing = BEARING_TRIBULATION // add this
 
+/datum/morality/lilith/seed
+	name = "Path of the Serepent's Seed"
+	desc = "A variant of Bahari beliefs, adherents of this prefer a much softer touch; to defeat Caine, they have no intent of destruction, they would much prefer to subvert the Noddists and bury his legacy."
+
+/datum/morality/lilith/midwives
+	name = "Path of the Red Midwives"
+	desc = "A variant of Bahari beliefs, those of this path find birth and creation to be their art. The inhuman and monstrous creatures around them, or those which are newly embraced, are a glory to behold and assist in searching for power in this world."
+
+/datum/morality/lilith/thorn
+	name = "Path of the Thorn Garden"
+	desc = "A variant of Bahari beliefs, those of the Thorns find a much stronger sense of justice imbued within them. Revenge is set aside in pursuit of the enforcement of code and law; with punishment doled out more than appropriately for those who breach it."
+
+/datum/morality/lilith/witches
+	name = "Path of the Lilin Witches"
+	desc = "A variant of Bahari beliefs, the witches seek the eldritch lore of the Dark Mother, defending their faithful and even working to cultivate Goddess cults amongst even mortals to venerate Her."
+
 /datum/morality/redemption
 	name = "Path of Redemption"
 	desc = "There are thousands of terms for God. Jesus, Yahweh, Allah, Ahura-Mazda. Yet one thing is certain: Vampires, being immortal, being cursed by God, witnessing the Great Flood, and being in the First City know that God is real. Followers of this Path are thus extremely devoted believers in their faith and religious principles, using the Curse as evidence of their chance for redemption on the day of their judgment by a benevolent creator. Indeed, vampires are outcasts of Heaven, but could this all be a test? Commonly called 'Martyrs', those who follow the Path of Redemption seek to redeem themselves by sacrificing themselves for others, undoing the selfish, animalistic pull of the Beast and making themselves worthy of the forgiveness of their chosen God (or Gods) once more. Yet God does not expect perfection. Followers of this path embrace the Divine Tide, or the natural cycle of sin, forgiveness, and rebirth. Followers of this Path are also often expected to take confession from members also on this Path, and confess, in turn. Vampires who follow this path are not saints - in fact, they recognize sin as an unfortunate, cyclical destiny as part of the Divine Tide, hoping to one day overcome it with a great and final act of martyrdom, redemption. Sins include not following the ethos of your religion, putting physical needs before spiritual, refusing to offer the opportunity of redemption to others, refusing to take or give confession, allowing a cardinal sin to go unpunished (such as lust, gluttony, anger, pride), and the murder of innocents. Blood Magic is looked down upon by this Path."
@@ -115,10 +155,10 @@
 	bearing = BEARING_FAITH
 
 /datum/morality/revelation
-	name = "Path of Revelations"
+	name = "Path of Evil Revelations"
 	desc = "The Demons, the Fallen Angels, were the first children of God, before man was made from clay, and before the life of Caine. The First Rebel, the Lord Lucifer, demanded explanations from God about His forbidden creations in Shadow, the Qlipphoth, and God not only denied him, but banished him from Heaven forevermore, along with his allies, for if God explained the nature of these creations to Lucifer, it would reveal that God is a fool. An unjust, tyrannical Father who plays favorites with his Children. This great injustice, hidden from the comprehension of mortals, will be undone when Lucifer completes his rebellion. His army of Demons outnumbers the Angels, and when the pretenders are thrown out, Creation will be made right. Vampires who follow the Path of Revelations, called 'Infernalists' thus obey and call themselves allies of Demons, believing themselves natural allies as both are outcasts of Heaven, outside the natural order - after all, vampires hunt humans, God's children. Followers of this Path do not merely accept their inner evil, plenty of other Paths offer that. To follow this Path requires a participation in a battle much more ancient than humankind, than vampirism, than creation itself, in service to an unfathomable 'evil'. Sins include obeying any laws, failing to observe infernalist rituals, altruistic acts, not grabbing power when the opportunity is present, showing self-interest, refusing to support infernal atrocities, failing to serve your Patron Demon, and allowing yourself to be defeated, or outsmarted, by the servants of God."
 	alignment = MORALITY_ENLIGHTENMENT
-	bearing = BEARING_TRIBULATION
+	bearing = BEARING_CORRUPTION
 
 /datum/morality/entelechy
 	name = "Path of Entelechy"
@@ -132,3 +172,20 @@
 	alignment = MORALITY_HUMANITY
 	bearing = BEARING_FAITH
 
+/datum/morality/paradox
+	name = "Path of Paradox"
+	desc = "The Path of Paradox is centered around the karmic duty Kindred hold. According to its adherents, Kindred have eluded samsara and hold a svadharma to fulfill; advancement of the cycle of the universe. This largely centers around either finding other Kindreds' role to play in this, or destroying them to return them to samsara."
+	alignment = MORALITY_ENLIGHTENMENT
+	bearing = BEARING_CONFIDENCE
+
+/datum/morality/self_focus
+	name = "Path of Self-Focus"
+	desc = "The Internalists of the Path of Self-Focus would find inaction and acceptance to be their code; they do not worry about what is or what is to be, they worry only about the now. They feed and kill when they need, yet find themselves considered slow and passive by most. A charitable observer may call them perceptive and introspective."
+	alignment = MORALITY_ENLIGHTENMENT
+	bearing = BEARING_BALANCE
+
+/datum/morality/assaku
+	name = "Path of Asakku"
+	desc = "Not truly a Path, Asakku represents a Kindred who has fallen to Vicissitude's pollution. This journey can begin either consciously or unconsciously, but the result is to be irrevocably altered - one cannot abandon this Path once it has been taken. Less a belief system and more a state of being, the Corrupted seek to spread Vicissitude as widely as possible; either by teaching it, crafting others with it, or destroying those who refuse it."
+	alignment = MORALITY_ENLIGHTENMENT
+	bearing = BEARING_cORRUPTION

--- a/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/paths.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/preferences/morality/paths.dm
@@ -188,4 +188,4 @@
 	name = "Path of Asakku"
 	desc = "Not truly a Path, Asakku represents a Kindred who has fallen to Vicissitude's pollution. This journey can begin either consciously or unconsciously, but the result is to be irrevocably altered - one cannot abandon this Path once it has been taken. Less a belief system and more a state of being, the Corrupted seek to spread Vicissitude as widely as possible; either by teaching it, crafting others with it, or destroying those who refuse it."
 	alignment = MORALITY_ENLIGHTENMENT
-	bearing = BEARING_cORRUPTION
+	bearing = BEARING_CORRUPTION


### PR DESCRIPTION

## About The Pull Request

Adds every VtM20 Path of Enlightenment except a few variations of Paradox. Also adjusts a few bearings and names to match V20.
## Why It's Good For The Game

v20 and long live the temple of set
## Changelog
:cl:
add: Added the Paths of Death and the Soul, Ecstasy, variants of Lilith, Night, Paradox, Self-Focus and the Warrior.
/:cl:
