### PR TITLE
joining with negative freebie points is not allowed

### DIFF
--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -166,6 +166,12 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 					tgui_alert(owner, "The server is full!", "Oh No!")
 					return TRUE
 
+			//DARKPACK EDIT ADD START - (prevents players from joining with negative freebie points)
+			var/datum/st_stat/freebie/freebie_stat = owner.client?.prefs?.preference_storyteller_stats[STAT_FREEBIE_POINTS]
+			if(freebie_stat && freebie_stat.get_points() < 0)
+				tgui_alert(owner, "You cannot join with negative freebie points! Please fix your character preferences.", "Oh No!")
+				return TRUE
+			// DARKPACK EDIT ADD END
 			// SAFETY: AttemptLateSpawn has it's own sanity checks. This is perfectly safe.
 			owner.AttemptLateSpawn(params["job"])
 		if("viewpoll")


### PR DESCRIPTION
## About The Pull Request

adds a tgui alert if you try to join the game with negative freebie points

<img width="1016" height="658" alt="dreamseeker_lPhU0yQMZZ" src="https://github.com/user-attachments/assets/91ad9d46-8d6a-44ab-bb4b-e192188e8fe0" />
<img width="920" height="770" alt="kvJ9k1mJpb" src="https://github.com/user-attachments/assets/694ebbdb-43e0-4e8e-a4d2-e2c99d91c420" />


## Why It's Good For The Game

preventing exploits

## Changelog
:cl:

fix: you can no longer join with negative freebie points

/:cl:

