### PR TITLE
Fix The Mixing Bowl

### DIFF
--- a/modular_darkpack/modules/food/code/drinks.dm
+++ b/modular_darkpack/modules/food/code/drinks.dm
@@ -141,11 +141,12 @@
 /obj/item/reagent_containers/condiment/milk/malk
 	desc = "a carton of fish-brand milk, a subsidary of malk incorporated."
 
-/obj/item/reagent_containers/glass/mixing_bowl
+/obj/item/reagent_containers/cup/mixing_bowl
 	name = "mixing bowl"
 	desc = "A mixing bowl. It can hold up to 50 units. Perfect for cooking"
 	icon = 'modular_darkpack/modules/food/icons/items.dmi'
 	ONFLOOR_ICON_HELPER('modular_darkpack/modules/food/icons/food_onfloor.dmi')
 	icon_state = "mixingbowl"
+	spillable = TRUE
 	custom_materials = list(/datum/material/glass=500)
 	custom_price = 10 // ECONOMY

--- a/modular_darkpack/modules/retail/code/stores/grocery_store.dm
+++ b/modular_darkpack/modules/retail/code/stores/grocery_store.dm
@@ -46,7 +46,7 @@
 		new /datum/data/vending_product("bruise pack", /obj/item/stack/medical/bruise_pack),
 		new /datum/data/vending_product("kitchen knife", /obj/item/knife, 26),
 		new /datum/data/vending_product("rolling pin", /obj/item/kitchen/rollingpin, 8),
-		new /datum/data/vending_product("mixing bowl", /obj/item/reagent_containers/glass/mixing_bowl),
+		new /datum/data/vending_product("mixing bowl", /obj/item/reagent_containers/cup/mixing_bowl),
 	)
 
 /obj/structure/retail/deli

--- a/tools/UpdatePaths/Scripts/DarkPack/115_mixingbowl.txt
+++ b/tools/UpdatePaths/Scripts/DarkPack/115_mixingbowl.txt
@@ -1,0 +1,1 @@
+ /obj/item/reagent_containers/glass/mixing_bowl :  /obj/item/reagent_containers/cup/mixing_bowl  {@OLD}


### PR DESCRIPTION

## About The Pull Request
Lets the mixing bowl be used, instead of just...doing nothing when you try to add liquids to it.
<details><summary>Screenshots</summary>
<p>
<img width="668" height="260" alt="Screenshot 2026-04-18 191305" src="https://github.com/user-attachments/assets/d7850137-bf59-45d6-91b3-ca90b8ed7f24" />
<img width="269" height="305" alt="Screenshot 2026-04-18 191319" src="https://github.com/user-attachments/assets/b00f6395-bb22-44ff-9bb5-e147b0ef9826" />
</p>
</details> 

## Why It's Good For The Game
Fix
## Changelog
:cl:
fix: Mixing Bowls can now be used.
/:cl:
