### PR TITLE
Pierce the Veil gives TRUE Night Vision

### DIFF
--- a/modular_darkpack/modules/ritual_abyss_mysticism/code/rituals/pierce_the_veil.dm
+++ b/modular_darkpack/modules/ritual_abyss_mysticism/code/rituals/pierce_the_veil.dm
@@ -9,7 +9,7 @@
 /obj/ritual_rune/abyss/pierce_the_veil/complete()
 	. = ..()
 	var/mob/living/carbon/human/H = last_activator
-	ADD_TRAIT(H, TRAIT_NIGHT_VISION, "pierce_the_veil")
+	ADD_TRAIT(H, TRAIT_TRUE_NIGHT_VISION, "pierce_the_veil")
 	ADD_TRAIT(H, TRAIT_MASQUERADE_VIOLATING_EYES, "pierce_the_veil")
 	to_chat(H, span_notice("Darkness floods your vision, then recedes - you can see clearly through the shadows now."))
 	H.update_sight()


### PR DESCRIPTION

## About The Pull Request
Changes Night Vision to True Night Vision from Pierce the Veil.
<details><summary>Screenshots</summary>
<p>
True Night Vision
<img width="404" height="298" alt="Screenshot 2026-04-24 234515" src="https://github.com/user-attachments/assets/7d4a8f17-95f1-43ce-8c0e-74b2f8df8097" /> 
Normal Night Vision
<img width="445" height="509" alt="Screenshot 2026-04-25 000534" src="https://github.com/user-attachments/assets/970eca4b-4ea8-478d-96cb-faff892a6a9c" />
</p>
</details> 

## Why It's Good For The Game
True night vision fits with how protean already does it, while basic night vision might be a little too weak.

## Changelog
:cl:
balance: Changes night vision granted by the pierce the veil ritual to be stronger
/:cl:
