### PR TITLE
Makes lightposts go out when the area power transformer is broken

### DIFF
--- a/_maps/map_files/Vampire/runtimetown.dmm
+++ b/_maps/map_files/Vampire/runtimetown.dmm
@@ -1095,6 +1095,10 @@
 "tY" = (
 /turf/open/floor/plating/canal,
 /area/vtm/outside/pacificheights)
+"uf" = (
+/obj/effect/turf_decal/bordur,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/outside/baywalk)
 "ug" = (
 /obj/machinery/door/airlock/elevator/right{
 	elevator_mode = 1;
@@ -1507,6 +1511,13 @@
 /obj/item/gun/ballistic/automatic/darkpack/sniper,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
+"Ce" = (
+/obj/effect/turf_decal/bordur{
+	dir = 1
+	},
+/obj/fusebox/transformer,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/outside/baywalk)
 "Ct" = (
 /obj/structure/lamppost/one{
 	dir = 1
@@ -1792,6 +1803,9 @@
 /obj/structure/vampdoor/prison,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/shop)
+"Gr" = (
+/turf/open/floor/plating/asphalt,
+/area/vtm/outside/baywalk)
 "Gt" = (
 /obj/structure/table,
 /obj/item/storage/medkit/darkpack/tox,
@@ -2389,6 +2403,11 @@
 /obj/effect/mapping_helpers/door/access/graveyard,
 /turf/open/floor/plating/rough,
 /area/vtm/graveyard/interior)
+"OA" = (
+/obj/effect/turf_decal/bordur,
+/obj/structure/lamppost/one,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/outside/baywalk)
 "OB" = (
 /obj/darkpack_car/police{
 	locked = 0
@@ -2568,6 +2587,11 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"QU" = (
+/obj/effect/turf_decal/bordur,
+/obj/structure/lamppost/one,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/outside/financialdistrict)
 "QW" = (
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/random/vending/snackvend,
@@ -2856,6 +2880,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
+"Wn" = (
+/obj/effect/turf_decal/bordur{
+	dir = 1
+	},
+/obj/fusebox/transformer,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/outside/financialdistrict)
 "Ws" = (
 /obj/structure/table,
 /obj/vampire_computer,
@@ -5750,11 +5781,11 @@ NR
 NR
 NR
 NR
-cj
-ik
+uf
+Gr
 VQ
 ik
-Fs
+Ce
 qt
 FO
 Wa
@@ -5818,8 +5849,8 @@ NR
 NR
 NR
 NR
-Bq
-ik
+OA
+Gr
 VQ
 ik
 Fs
@@ -6430,11 +6461,11 @@ NR
 NR
 NR
 NR
-Bq
+QU
 ik
 VQ
 ik
-Fs
+Wn
 Wa
 Wa
 Mn

--- a/modular_darkpack/modules/areas/code/outsides/__outside.dm
+++ b/modular_darkpack/modules/areas/code/outsides/__outside.dm
@@ -2,3 +2,4 @@
 /area/vtm/outside
 	outdoors = TRUE
 	sound_environment = SOUND_ENVIRONMENT_CITY
+	requires_power = TRUE // set false in subtypes -- most outside areas require power and have lampposts and such in big cities

--- a/modular_darkpack/modules/areas/code/outsides/forest.dm
+++ b/modular_darkpack/modules/areas/code/outsides/forest.dm
@@ -5,3 +5,4 @@
 	sound_environment = SOUND_ENVIRONMENT_FOREST
 	gauntlet_rating = 6
 	domain = TRUE
+	requires_power = FALSE

--- a/modular_darkpack/modules/decor/code/decor.dm
+++ b/modular_darkpack/modules/decor/code/decor.dm
@@ -55,10 +55,9 @@
 	RegisterSignal(get_area(src), COMSIG_AREA_POWER_CHANGE, PROC_REF(on_power_change))
 	create_lights()
 
-/obj/structure/lamppost/proc/on_power_change(datum/source)
+/obj/structure/lamppost/proc/on_power_change(area/A)
 	SIGNAL_HANDLER
 
-	var/area/A = source
 
 	if(A.power_light)
 		create_lights()

--- a/modular_darkpack/modules/decor/code/decor.dm
+++ b/modular_darkpack/modules/decor/code/decor.dm
@@ -48,12 +48,14 @@
 
 /obj/structure/lamppost/Initialize(mapload)
 	. = ..()
+	var/area/vtm/my_area = get_area(src)
 	if(check_holidays(FESTIVE_SEASON))
-		var/area/my_area = get_area(src)
 		if(istype(my_area) && my_area.outdoors)
 			icon_state = "[initial(icon_state)]-snow"
-	RegisterSignal(get_area(src), COMSIG_AREA_POWER_CHANGE, PROC_REF(on_power_change))
-	create_lights()
+	if(my_area.requires_power)
+		RegisterSignal(my_area, COMSIG_AREA_POWER_CHANGE, PROC_REF(on_power_change))
+		if(my_area.powered())
+			create_lights()
 
 /obj/structure/lamppost/proc/on_power_change(datum/source)
 	SIGNAL_HANDLER

--- a/modular_darkpack/modules/decor/code/decor.dm
+++ b/modular_darkpack/modules/decor/code/decor.dm
@@ -52,6 +52,21 @@
 		var/area/my_area = get_area(src)
 		if(istype(my_area) && my_area.outdoors)
 			icon_state = "[initial(icon_state)]-snow"
+	RegisterSignal(get_area(src), COMSIG_AREA_POWER_CHANGE, PROC_REF(on_power_change))
+	create_lights()
+
+/obj/structure/lamppost/proc/on_power_change(datum/source)
+	SIGNAL_HANDLER
+
+	var/area/A = source
+
+	if(A.power_light)
+		create_lights()
+	else
+		QDEL_LIST(my_lights)
+
+/obj/structure/lamppost/proc/create_lights()
+	QDEL_LIST(my_lights)
 	switch(number_of_lamps)
 		if(1)
 			new_light(get_step(loc, dir))
@@ -74,6 +89,7 @@
 	my_lights += new /obj/effect/decal/lamplight(location)
 
 /obj/structure/lamppost/Destroy(force)
+	UnregisterSignal(get_area(src), COMSIG_AREA_POWER_CHANGE)
 	QDEL_LIST(my_lights)
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request

makes lightposts go out when the area power transformer is broken

also wanna make them flicker

<img width="760" height="514" alt="dreamseeker_Bn0gwoRGdK" src="https://github.com/user-attachments/assets/a66aebc9-8484-46bd-bd09-37f96e836b3f" />


## Why It's Good For The Game

this is cool

## Changelog
:cl:
add: makes lightposts go out when the area power transformer is broken

/:cl:

