### PR TITLE
uses the generic healing proc for bloodheal

### DIFF
--- a/modular_darkpack/modules/aggravated_damage/code/generic_healing.dm
+++ b/modular_darkpack/modules/aggravated_damage/code/generic_healing.dm
@@ -58,8 +58,8 @@
 /mob/living/proc/get_storyteller_damage(heal_aggravated = FALSE, heal_scars = FALSE, heal_blood = FALSE)
 	var/damage_dots = 0
 	if(heal_aggravated)
-		damage_dots += round(get_agg_loss()+get_fire_loss(), 1 TTRPG_DAMAGE) / 1 TTRPG_DAMAGE
-	damage_dots += round(get_brute_loss()+get_tox_loss()+get_oxy_loss(), 1 TTRPG_DAMAGE) / 1 TTRPG_DAMAGE
+		damage_dots += round(get_agg_loss()+get_fire_loss(), 1 TTRPG_DAMAGE) / (1 TTRPG_DAMAGE)
+	damage_dots += round(get_brute_loss()+get_tox_loss()+get_oxy_loss(), 1 TTRPG_DAMAGE) / (1 TTRPG_DAMAGE)
 
 	if(heal_scars)
 		damage_dots += get_storyteller_scars_damage()

--- a/modular_darkpack/modules/aggravated_damage/code/generic_healing.dm
+++ b/modular_darkpack/modules/aggravated_damage/code/generic_healing.dm
@@ -53,13 +53,13 @@
 	return healed_dots
 
 
-// Its not FULLY 1 to 1 with the amount of dots I think. but its close enough for guessing how much vitate it would cost to heal for example.
+// Its not FULLY 1 to 1 with the amount of dots I think. I think the rounding can cut off a dice or two? but its close enough for guessing how much vitate it would cost to heal for example.
 /// Returns amount of "dots" of damage the mob currently has.
 /mob/living/proc/get_storyteller_damage(heal_aggravated = FALSE, heal_scars = FALSE, heal_blood = FALSE)
 	var/damage_dots = 0
 	if(heal_aggravated)
-		damage_dots += round(get_agg_loss()+get_fire_loss(), 1 TTRPG_DAMAGE)
-	damage_dots += round(get_brute_loss()+get_tox_loss()+get_oxy_loss(), 1 TTRPG_DAMAGE)
+		damage_dots += round(get_agg_loss()+get_fire_loss(), 1 TTRPG_DAMAGE) / 1 TTRPG_DAMAGE
+	damage_dots += round(get_brute_loss()+get_tox_loss()+get_oxy_loss(), 1 TTRPG_DAMAGE) / 1 TTRPG_DAMAGE
 
 	if(heal_scars)
 		damage_dots += get_storyteller_scars_damage()

--- a/modular_darkpack/modules/aggravated_damage/code/generic_healing.dm
+++ b/modular_darkpack/modules/aggravated_damage/code/generic_healing.dm
@@ -7,9 +7,6 @@
 
 	var/healed_dots = 0
 
-	if(heal_blood)
-		adjust_blood_volume(dots_to_heal * 2)
-
 	if(heal_scars && dots_to_heal > 0)
 		healed_dots += heal_storyteller_scars(dots_to_heal)
 
@@ -23,6 +20,9 @@
 		heal_ordered_damage(1 TTRPG_DAMAGE, list(BRUTE, TOX, OXY))
 		dots_to_heal--
 		healed_dots++
+
+	if(heal_blood)
+		adjust_blood_volume(dots_to_heal * 2, maximum = BLOOD_VOLUME_NORMAL) // Idk. this one doesnt cost anything.
 
 	if(healed_dots)
 		updatehealth()
@@ -52,3 +52,33 @@
 
 	return healed_dots
 
+
+// Its not FULLY 1 to 1 with the amount of dots I think. but its close enough for guessing how much vitate it would cost to heal for example.
+/// Returns amount of "dots" of damage the mob currently has.
+/mob/living/proc/get_storyteller_damage(heal_aggravated = FALSE, heal_scars = FALSE, heal_blood = FALSE)
+	var/damage_dots = 0
+	if(heal_aggravated)
+		damage_dots += round(get_agg_loss()+get_fire_loss(), 1 TTRPG_DAMAGE)
+	damage_dots += round(get_brute_loss()+get_tox_loss()+get_oxy_loss(), 1 TTRPG_DAMAGE)
+
+	if(heal_scars)
+		damage_dots += get_storyteller_scars_damage()
+
+	return damage_dots
+
+/mob/living/proc/get_storyteller_scars_damage()
+	return
+
+/mob/living/carbon/get_storyteller_scars_damage()
+	var/damage_dots = 0
+
+	for(var/datum/wound/our_wound in all_wounds)
+		damage_dots++
+
+	// W20 p. 259: describes "battle scars" to be inclusive of stuff like organ damage, brain damage or lost limbs.
+	for(var/obj/item/organ/target_organ as anything in organs)
+		if(!target_organ.damage)
+			continue
+		damage_dots++
+
+	return damage_dots

--- a/modular_darkpack/modules/powers/code/discipline/bloodheal/bloodheal.dm
+++ b/modular_darkpack/modules/powers/code/discipline/bloodheal/bloodheal.dm
@@ -1,6 +1,3 @@
-#define HEAL_BASHING_LETHAL_DAMAGE 30
-#define HEAL_AGGRAVATED_DAMAGE 6
-
 /datum/discipline/bloodheal
 	name = "Bloodheal"
 	desc = "Use the power of your Vitae to mend your flesh."
@@ -67,33 +64,8 @@
 /datum/discipline_power/bloodheal/activate()
 	. = ..()
 
-	//normal bashing/lethal damage
-	owner.heal_ordered_damage(HEAL_BASHING_LETHAL_DAMAGE * vitae_cost, list(BRUTE, TOX, OXY, STAMINA))
-
-	if(length(owner.all_wounds))
-		for (var/i in 1 to min(vitae_cost, length(owner.all_wounds)))
-			var/datum/wound/wound = owner.all_wounds[i]
-			wound.remove_wound()
-
-	//aggravated damage
-	owner.heal_ordered_damage(HEAL_AGGRAVATED_DAMAGE * vitae_cost, list(BURN, AGGRAVATED))
-
-	//brain damage and traumas healing
-	var/obj/item/organ/brain/brain = owner.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if (brain)
-		brain.apply_organ_damage(-HEAL_BASHING_LETHAL_DAMAGE * vitae_cost)
-
-		for (var/i in 1 to min(vitae_cost, length(brain.get_traumas_type())))
-			var/datum/brain_trauma/healing_trauma = pick(brain.get_traumas_type())
-			brain.cure_trauma_type(healing_trauma, resilience = TRAUMA_RESILIENCE_WOUND)
-
-	//miscellaneous organ damage healing
-	var/obj/item/organ/eyes/eyes = owner.get_organ_slot(ORGAN_SLOT_EYES)
-	if (eyes)
-		eyes.apply_organ_damage(-HEAL_BASHING_LETHAL_DAMAGE * vitae_cost)
-
-		owner.adjust_temp_blindness(-HEAL_AGGRAVATED_DAMAGE * vitae_cost)
-		owner.adjust_eye_blur(-HEAL_AGGRAVATED_DAMAGE * vitae_cost)
+	// 2 to represent leathal***
+	owner.heal_storyteller_health(vitae_cost * 2, heal_scars = TRUE)
 
 	//healing too quickly attracts attention
 	if (violates_masquerade)
@@ -102,10 +74,6 @@
 			span_warning("Your wounds visibly heal with unnatural speed!")
 		)
 
-	//update UI
-	owner.update_damage_overlays()
-	owner.update_health_hud()
-
 /datum/discipline_power/bloodheal/spend_resources()
 	adjust_vitae_cost()
 
@@ -113,15 +81,8 @@
 
 /datum/discipline_power/bloodheal/proc/adjust_vitae_cost()
 	vitae_cost = initial(vitae_cost)
-	//tally up damage
-	var/total_bashing_lethal_damage = owner.get_brute_loss() + owner.get_tox_loss() + owner.get_oxy_loss()
-	var/total_aggravated_damage = owner.get_agg_loss() + owner.get_fire_loss()
 
-	//lower blood expenditure to what's necessary
-	var/vitae_to_heal_bashing_lethal = ceil(total_bashing_lethal_damage / HEAL_BASHING_LETHAL_DAMAGE)
-	var/vitae_to_heal_aggravated = ceil(total_aggravated_damage / HEAL_AGGRAVATED_DAMAGE)
-
-	var/vitae_needed = max(vitae_to_heal_bashing_lethal, vitae_to_heal_aggravated)
+	var/vitae_needed = owner.get_storyteller_damage(heal_scars = TRUE)
 
 	//vitae used to heal is the smaller of max vitae expenditure and what's needed to heal the damage
 	vitae_cost = max(min(vitae_cost, vitae_needed), 1)
@@ -231,6 +192,3 @@
 	vitae_cost = 10
 
 	violates_masquerade = TRUE
-
-#undef HEAL_BASHING_LETHAL_DAMAGE
-#undef HEAL_AGGRAVATED_DAMAGE

--- a/modular_darkpack/modules/powers/code/discipline/bloodheal/bloodheal.dm
+++ b/modular_darkpack/modules/powers/code/discipline/bloodheal/bloodheal.dm
@@ -64,7 +64,7 @@
 /datum/discipline_power/bloodheal/activate()
 	. = ..()
 
-	// 2 to represent leathal***
+	// 2 to represent lethal***
 	owner.heal_storyteller_health(vitae_cost * 2, heal_scars = TRUE)
 
 	//healing too quickly attracts attention
@@ -82,7 +82,7 @@
 /datum/discipline_power/bloodheal/proc/adjust_vitae_cost()
 	vitae_cost = initial(vitae_cost)
 
-	var/vitae_needed = owner.get_storyteller_damage(heal_scars = TRUE)
+	var/vitae_needed = owner.get_storyteller_damage(heal_scars = TRUE) / 2
 
 	//vitae used to heal is the smaller of max vitae expenditure and what's needed to heal the damage
 	vitae_cost = max(min(vitae_cost, vitae_needed), 1)

--- a/modular_darkpack/modules/powers/code/discipline/bloodheal/bloodheal.dm
+++ b/modular_darkpack/modules/powers/code/discipline/bloodheal/bloodheal.dm
@@ -82,7 +82,7 @@
 /datum/discipline_power/bloodheal/proc/adjust_vitae_cost()
 	vitae_cost = initial(vitae_cost)
 
-	var/vitae_needed = owner.get_storyteller_damage(heal_scars = TRUE) / 2
+	var/vitae_needed = round(owner.get_storyteller_damage(heal_scars = TRUE) / 2)
 
 	//vitae used to heal is the smaller of max vitae expenditure and what's needed to heal the damage
 	vitae_cost = max(min(vitae_cost, vitae_needed), 1)

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_splat.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_splat.dm
@@ -141,7 +141,7 @@
 		// their fast healing is represented in day/days in breed-form so we just dont.
 		if(is_breed_form() && (get_breed_form_species() != /datum/species/human/shifter/war))
 			return
-		// 2 to represent leathal***
+		// 2 to represent lethal***
 		owner.heal_storyteller_health(2, heal_scars = TRUE, heal_blood = TRUE)
 		COOLDOWN_START(src, passive_healing_cd, 1 TURNS)
 	var/datum/species/human/shifter/shifter_species = owner.dna.species


### PR DESCRIPTION

## About The Pull Request
see title, also added a new proc that instead of directly healing, just counts up all the damage, to replace how bloodheal spends vitae.

this is notably NOT one to one with the numbers the old code used.

## Why It's Good For The Game
There is multiple forms of healing that comes down to "heal this amount of dots". Vampire bloodheal is one of these.
most other now use this proc, but bloodheal did not, now it does, and that even means it heals some bonus sources.
## Changelog
:cl:
balance: Bloodheal now uses the same generic healing proc as werewolf, obeah, and some other healing sources use
/:cl:
