### PR TITLE
Adding factions to jobs

### DIFF
--- a/code/__DEFINES/~darkpack/factions.dm
+++ b/code/__DEFINES/~darkpack/factions.dm
@@ -4,8 +4,10 @@
 #define FACTION_ANARCHS "anarchs"
 #define FACTION_CAMARILLA "camarilla"
 #define FACTION_SABBAT "sabbat"
+#define FACTION_GIOVANNI "giovanni"
 
 // City faction
 #define FACTION_CITY "city"
 
 #define FACTION_GAIA "gaia"
+#define FACTION_PENTEX "pentex"

--- a/code/__DEFINES/~darkpack/factions.dm
+++ b/code/__DEFINES/~darkpack/factions.dm
@@ -4,7 +4,7 @@
 #define FACTION_ANARCHS "anarchs"
 #define FACTION_CAMARILLA "camarilla"
 #define FACTION_SABBAT "sabbat"
-#define FACTION_GIOVANNI "giovanni"
+#define FACTION_GIOVANNI "giovanni-faction"
 
 // City faction
 #define FACTION_CITY "city"

--- a/code/modules/client/preferences/middleware/jobs.dm
+++ b/code/modules/client/preferences/middleware/jobs.dm
@@ -18,8 +18,10 @@
 	if (isnull(job))
 		return FALSE
 
+	/* DARKPACK EDIT REMOVAL - Factions - note: why do these lines even exist?
 	if (job.faction != FACTION_CITY) // DARKPACK EDIT, ORGINAL: if (job.faction != FACTION_STATION)
 		return FALSE
+	*/
 
 	if (!preferences.set_job_preference_level(job, level))
 		return FALSE

--- a/modular_darkpack/modules/jobs/code/_jobs.dm
+++ b/modular_darkpack/modules/jobs/code/_jobs.dm
@@ -121,4 +121,4 @@
 
 /datum/job/vampire/after_spawn(mob/living/spawned, client/player_client)
 	. = ..()
-	spawned.add_faction(src.faction)
+	spawned.add_faction(faction)

--- a/modular_darkpack/modules/jobs/code/_jobs.dm
+++ b/modular_darkpack/modules/jobs/code/_jobs.dm
@@ -118,3 +118,7 @@
 /// Returns information pertaining to this job's radio.
 /datum/job/vampire/get_radio_information()
 	return
+
+/datum/job/vampire/after_spawn(mob/living/spawned, client/player_client)
+	. = ..()
+	spawned.add_faction(src.faction)

--- a/modular_darkpack/modules/jobs/code/anarchs/baron.dm
+++ b/modular_darkpack/modules/jobs/code/anarchs/baron.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/baron
 	title = JOB_BARON
-	faction = FACTION_CITY
+	faction = FACTION_ANARCHS
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Anarchs and the Traditions"

--- a/modular_darkpack/modules/jobs/code/anarchs/bruiser.dm
+++ b/modular_darkpack/modules/jobs/code/anarchs/bruiser.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/bruiser
 	title = JOB_BRUISER
-	faction = FACTION_CITY
+	faction = FACTION_ANARCHS
 	total_positions = 7
 	spawn_positions = 7
 	supervisors = SUPERVISOR_BARON

--- a/modular_darkpack/modules/jobs/code/anarchs/emissary.dm
+++ b/modular_darkpack/modules/jobs/code/anarchs/emissary.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/emissary
 	title = JOB_EMISSARY
-	faction = FACTION_CITY
+	faction = FACTION_ANARCHS
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_BARON

--- a/modular_darkpack/modules/jobs/code/anarchs/sweeper.dm
+++ b/modular_darkpack/modules/jobs/code/anarchs/sweeper.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/sweeper
 	title = JOB_SWEEPER
-	faction = FACTION_CITY
+	faction = FACTION_ANARCHS
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = SUPERVISOR_BARON

--- a/modular_darkpack/modules/jobs/code/anarchs/tapster.dm
+++ b/modular_darkpack/modules/jobs/code/anarchs/tapster.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/tapster
 	title = JOB_TAPSTER
-	faction = FACTION_CITY
+	faction = FACTION_ANARCHS
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = SUPERVISOR_BARON_PUBLIC

--- a/modular_darkpack/modules/jobs/code/camarilla/harpy.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/harpy.dm
@@ -2,7 +2,7 @@
 	title = JOB_HARPY
 	description = "You are an expert on the nightlife of Cainite society. Acting as one of the chief advisors on all things related to boons and diplomacy, the Prince defers quite the amount of judgement to you. Don't squander it."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = SUPERVISOR_PRINCE

--- a/modular_darkpack/modules/jobs/code/camarilla/hound.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/hound.dm
@@ -2,7 +2,7 @@
 	title = JOB_HOUND
 	description = "You are the Prince's enforcer. You report to the Sheriff and uphold the Traditions."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 7
 	spawn_positions = 7
 	supervisors = SUPERVISOR_SHERIFF

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/banu_haqim.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/banu_haqim.dm
@@ -2,7 +2,7 @@
 	title = JOB_PRIMOGEN_BANU_HAQIM
 	description = "Offer your infinite knowledge to Prince of the City, while overseeing the Banu Haqim in the city. Monitor their contracts and ensure they remain true to the ways of the Clan. You have an official cover with the Police Department as a local civilian consultant, ensure things run smoothly, on either end."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_TRADITIONS

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/lasombra.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/lasombra.dm
@@ -2,7 +2,7 @@
 	title = JOB_PRIMOGEN_LASOMBRA
 	description = "Offer your infinite knowledge to Prince of the City. Monitor those of your Clan and your lesser cousins, while holding a Court of Blood as need be, for all it takes for the Camarilla to turn on you is one mistake. You and Your Clan were given a domain in the local Church and in the vicinity of a swarm of Lupines, keep matters under control."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_TRADITIONS

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/malkavian.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/malkavian.dm
@@ -2,7 +2,7 @@
 	title = JOB_PRIMOGEN_MALKAVIAN
 	description = "Offer your infinite knowledge to Prince of the City. You likely have a hold over the local hospital, make good use of it and ensure the blood bags remain available."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_TRADITIONS

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/nosferatu.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/nosferatu.dm
@@ -2,7 +2,7 @@
 	title = JOB_PRIMOGEN_NOSFERATU
 	description = "Offer your infinite knowledge to Prince of the City, and run the warren, your domain watches over the sewers."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_TRADITIONS

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/toreador.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/toreador.dm
@@ -2,7 +2,7 @@
 	title = JOB_PRIMOGEN_TOREADOR
 	description = "Offer your infinite knowledge to Prince of the City. Take care of the Strip Club and its Elysium, for it is your domain and a social center within the city."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_TRADITIONS

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/ventrue.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/ventrue.dm
@@ -2,7 +2,7 @@
 	title = JOB_PRIMOGEN_VENTRUE
 	description = "Offer your infinite knowledge to Prince of the City. Maintain the local Jazz Club, in front of the Tower, and its Elysium."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_TRADITIONS

--- a/modular_darkpack/modules/jobs/code/camarilla/prince.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/prince.dm
@@ -2,7 +2,7 @@
 	title = JOB_PRINCE
 	description = "You are the top dog of this city. You hold Praxis over " + CITY_NAME + ", and your word is law. Make sure the Masquerade is upheld, and your status is respected."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_TRADITIONS

--- a/modular_darkpack/modules/jobs/code/camarilla/seneschal.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/seneschal.dm
@@ -2,7 +2,7 @@
 	title = JOB_SENESCHAL
 	description = "You are the right hand man or woman of the most powerful vampire in the city. The Camarilla trusts you to run the city, even in their stead."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_PRINCE

--- a/modular_darkpack/modules/jobs/code/camarilla/sheriff.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/sheriff.dm
@@ -2,7 +2,7 @@
 	title = JOB_SHERIFF
 	description = "Protect the Prince and the Masquerade. You are their sword."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD|DEADMIN_POSITION_SECURITY
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_PRINCE

--- a/modular_darkpack/modules/jobs/code/camarilla/tower_employee.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/tower_employee.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/towerwork
 	title = JOB_TOWERWORK
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 4
 	spawn_positions = 4
 	supervisors = SUPERVISOR_SENESCHAL_PUBLIC

--- a/modular_darkpack/modules/jobs/code/garou/councillor.dm
+++ b/modular_darkpack/modules/jobs/code/garou/councillor.dm
@@ -2,7 +2,7 @@
 	title = JOB_GAROU_COUNCIL
 	description = "Veterans of the Garou Nation with the highest esteem, your word within the " + SEPT_NAME + " is law. Make sure the Litany is upheld, and that your caern does not fall prey to the Wyrm."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_GAIA
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = SUPERVISOR_LITANY

--- a/modular_darkpack/modules/jobs/code/garou/guardian.dm
+++ b/modular_darkpack/modules/jobs/code/garou/guardian.dm
@@ -2,7 +2,7 @@
 	title = JOB_GAROU_GUARDIAN
 	description = "You are the bottom of the Sept's pecking order, but also the frontline offense and defense, serving directly under the Warder and Wyrmfoe to ensure the caern's safety and well-being."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
-	faction = FACTION_CITY
+	faction = FACTION_GAIA
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = /datum/job/vampire/warder

--- a/modular_darkpack/modules/jobs/code/garou/truthcatcher.dm
+++ b/modular_darkpack/modules/jobs/code/garou/truthcatcher.dm
@@ -2,7 +2,7 @@
 	title = JOB_GAROU_TRUTHCATCHER
 	description = "You are the most highly regarded Philodox within the Sept, granted the honor of being the ultimate arbitrator. It is your duty to meditate matters within the Sept. Enact your judgement upon anyone who violates the Litany."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
-	faction = FACTION_CITY
+	faction = FACTION_GAIA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_LITANY

--- a/modular_darkpack/modules/jobs/code/garou/warder.dm
+++ b/modular_darkpack/modules/jobs/code/garou/warder.dm
@@ -2,7 +2,7 @@
 	title = JOB_GAROU_WARDER
 	description = "You are the most respected Ahroun within the" + SEPT_NAME + ", granted the honor of coordinating the caern's security. The Wyrmfoe and Guardians answer to you."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
-	faction = FACTION_CITY
+	faction = FACTION_GAIA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_LITANY

--- a/modular_darkpack/modules/jobs/code/garou/wyrmfoe.dm
+++ b/modular_darkpack/modules/jobs/code/garou/wyrmfoe.dm
@@ -2,7 +2,7 @@
 	title = JOB_GAROU_WYRMFOE
 	description = "You are the Warder's right hand, a promising tactician in your own right, granted the honor of coordinating the Sept's more offensive actions. "
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
-	faction = FACTION_CITY
+	faction = FACTION_GAIA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_LITANY

--- a/modular_darkpack/modules/jobs/code/giovanni/capo.dm
+++ b/modular_darkpack/modules/jobs/code/giovanni/capo.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/capo
 	title = JOB_CAPO
-	faction = FACTION_CITY
+	faction = FACTION_GIOVANNI
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Family and the Traditions"

--- a/modular_darkpack/modules/jobs/code/giovanni/la_famiglia.dm
+++ b/modular_darkpack/modules/jobs/code/giovanni/la_famiglia.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/famiglia
 	title = JOB_LA_FAMIGLIA
-	faction = FACTION_CITY
+	faction = FACTION_GIOVANNI
 	total_positions = 10
 	spawn_positions = 10
 	supervisors = "the Family"

--- a/modular_darkpack/modules/jobs/code/giovanni/la_squadra.dm
+++ b/modular_darkpack/modules/jobs/code/giovanni/la_squadra.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/squadra
 	title = JOB_LA_SQUADRA
-	faction = FACTION_CITY
+	faction = FACTION_GIOVANNI
 	total_positions = 10
 	spawn_positions = 10
 	supervisors = "the Family and the Traditions"

--- a/modular_darkpack/modules/jobs/code/pentex/affairs.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/affairs.dm
@@ -2,7 +2,7 @@
 	title = JOB_PENTEX_AFFAIRS
 	description = "You are the internal affairs agent operating for " + MAIN_EVIL_COMPANY + ". You know the bloody and vile needs commanded of destruction will lead to jeopardy, and your duty is to see excellence on task rewarded and acknowledged, and curb the invariable atrocities that could endanger the greater plans of Pentex."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_PENTEX
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Board and the Branch Lead"

--- a/modular_darkpack/modules/jobs/code/pentex/branch_lead.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/branch_lead.dm
@@ -2,7 +2,7 @@
 	title = JOB_PENTEX_LEAD
 	description = "You are the current branch leader for " + MAIN_EVIL_COMPANY + " , operating out of San Francisco. Your job is to fuel production and keep your clowns in line."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_PENTEX
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Board"

--- a/modular_darkpack/modules/jobs/code/pentex/employee.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/employee.dm
@@ -2,7 +2,7 @@
 	title = JOB_PENTEX_EMPLOYEE
 	description = "You are an employee for " + MAIN_EVIL_COMPANY + ", operating out of San Francisco. Your bosses can be a little strange; give credence to the security team and executives for tasks on the night shift, and avoid getting negative attention from the branch manager or internal affairs."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_PENTEX
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the Board and the Branch Lead"

--- a/modular_darkpack/modules/jobs/code/pentex/executive.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/executive.dm
@@ -2,7 +2,7 @@
 	title = JOB_PENTEX_EXEC
 	description = "You are an acting executive for " + MAIN_EVIL_COMPANY + " operating out of San Francisco. With discretion to the Branch Leader, a position you may aim for, your job is to fuel production and expand operations."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_PENTEX
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Board and the Branch Lead"

--- a/modular_darkpack/modules/jobs/code/pentex/sec.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/sec.dm
@@ -2,7 +2,7 @@
 	title = JOB_PENTEX_SEC
 	description = "You are an acting security for " + MAIN_EVIL_COMPANY + ", operating out of San Francisco. Under the chief of security's direction, your job is to keep the complex free of nosy meddlers, pick up contract violators, and to assist the chief in tackling threats to corporate assets."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_PENTEX
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the Board, Branch Lead, and Chief of Security"

--- a/modular_darkpack/modules/jobs/code/pentex/secchief.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/secchief.dm
@@ -2,7 +2,7 @@
 	title = JOB_PENTEX_SEC_CHIEF
 	description = "You are an acting chief of security for the Endron Oil Refinery, operating out of San Francisco. With discretion to the Branch Leader, your job is to keep the complex and it's proprietary information with the help of your security team, and to turn over contract violators to internal affairs or the executives."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
-	faction = FACTION_CITY
+	faction = FACTION_PENTEX
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Board and the Branch Lead"

--- a/modular_darkpack/modules/jobs/code/sabbat/ductus.dm
+++ b/modular_darkpack/modules/jobs/code/sabbat/ductus.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/sabbatductus
 	title = JOB_SABBAT_DUCTUS
-	faction = FACTION_CITY
+	faction = FACTION_SABBAT
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "Caine"

--- a/modular_darkpack/modules/jobs/code/sabbat/pack.dm
+++ b/modular_darkpack/modules/jobs/code/sabbat/pack.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/sabbatpack
 	title = JOB_SABBAT_PACK
-	faction = FACTION_CITY
+	faction = FACTION_SABBAT
 	total_positions = 5
 	spawn_positions = 5
 	supervisors = "Caine"

--- a/modular_darkpack/modules/jobs/code/sabbat/priest.dm
+++ b/modular_darkpack/modules/jobs/code/sabbat/priest.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/sabbatpriest
 	title = JOB_SABBAT_PRIEST
-	faction = FACTION_CITY
+	faction = FACTION_SABBAT
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "Caine"

--- a/modular_darkpack/modules/jobs/code/tremere/archivist.dm
+++ b/modular_darkpack/modules/jobs/code/tremere/archivist.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/archivist
 	title = JOB_CHANTRY_ARCHIVIST
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 4
 	spawn_positions = 4
 	supervisors = SUPERVISOR_REGENT

--- a/modular_darkpack/modules/jobs/code/tremere/gargoyle.dm
+++ b/modular_darkpack/modules/jobs/code/tremere/gargoyle.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/gargoyle
 	title = JOB_CHANTRY_GARGOYLE
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 5
 	spawn_positions = 5
 	supervisors = SUPERVISOR_REGENT

--- a/modular_darkpack/modules/jobs/code/tremere/regent.dm
+++ b/modular_darkpack/modules/jobs/code/tremere/regent.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/regent
 	title = JOB_CHANTRY_REGENT
-	faction = FACTION_CITY
+	faction = FACTION_CAMARILLA
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = SUPERVISOR_CAMARILLA

--- a/modular_darkpack/modules/jobs/code/tzimisce/bogatyr.dm
+++ b/modular_darkpack/modules/jobs/code/tzimisce/bogatyr.dm
@@ -1,7 +1,7 @@
 
 /datum/job/vampire/bogatyr
 	title = JOB_BOGATYR
-	faction = FACTION_CITY
+	faction = FACTION_SABBAT
 	total_positions = 4
 	spawn_positions = 4
 	supervisors = " the Laws of Hospitality"

--- a/modular_darkpack/modules/jobs/code/tzimisce/voivode.dm
+++ b/modular_darkpack/modules/jobs/code/tzimisce/voivode.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/voivode
 	title = JOB_VOIVODE
-	faction = FACTION_CITY
+	faction = FACTION_SABBAT
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = " the Laws of Hospitality"

--- a/modular_darkpack/modules/jobs/code/tzimisce/zadruga.dm
+++ b/modular_darkpack/modules/jobs/code/tzimisce/zadruga.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/zadruga
 	title = JOB_ZADRUGA
-	faction = FACTION_CITY
+	faction = FACTION_SABBAT
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = " the Laws of Hospitality"

--- a/modular_darkpack/modules/retail/code/_retail.dm
+++ b/modular_darkpack/modules/retail/code/_retail.dm
@@ -12,7 +12,6 @@
 	anchored_tabletop_offset = 6
 	var/owner_needed = TRUE //Does an npc need to be here for this
 	var/mob/living/carbon/human/npc/my_owner //tracks existence of owner
-	var/is_gun_store = FALSE
 	var/payment_department = ACCOUNT_SRV
 
 	var/list/datum/data/vending_product/products_list = list()


### PR DESCRIPTION
## About The Pull Request

adding factions to jobs, these are needed for gameplay loops that are planned, they are currently all 'FACTION_CITY' because for some reason in jobcode if jobs arent FACTION_STATION (renamed to FACTION_CITY in our modular edits) then you just cant select them in prefs. 

## Why It's Good For The Game

i can use this var for gameplay loops

## Changelog

:cl:

code: every job datum now has a faction
code: removes unused and useless 'is_gun_store' job on /obj/structure/retail

/:cl:


