### PR TITLE
Brawl prefers the highest damage attack

### DIFF
--- a/code/modules/mob/living/basic/basic_defense.dm
+++ b/code/modules/mob/living/basic/basic_defense.dm
@@ -54,6 +54,10 @@
 		attack_roll_type = /datum/storyteller_roll/attack/kick
 		damage_roll_type = /datum/storyteller_roll/damage/kick
 		damage_bonus_dice++
+	else if(atk_effect == ATTACK_EFFECT_CLAW)
+		attack_roll_type = /datum/storyteller_roll/attack/claw
+		damage_roll_type = /datum/storyteller_roll/damage/claw
+		damage_bonus_dice += 2
 
 	user.do_attack_animation(src, atk_effect)
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -739,8 +739,8 @@
 		return FALSE
 	// Now lets acctually compare them
 	if(active_hand.attack_type == AGGRAVATED)
-		return FALSE // AGG damage is gonna almost always be better dps..
-	if(active_hand.atk_effect == ATTACK_EFFECT_CLAW)
+		return FALSE // AGG damage is gonna almost always be better dps or more desired..
+	if(active_hand.unarmed_attack_effect == ATTACK_EFFECT_CLAW)
 		return FALSE // Claws get an extra bonus dice compared to kicking
 	return TRUE // Otherwise, kicking is PROBALLY better as it gets a +1 bonus to damage compared to punches.
 // DARKPACK EDIT ADD END

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -724,10 +724,26 @@
 		return found_head || active_hand // If we are a feral biter, return a usable head.
 	if(target.pulledby == owner) // if we're grabbing our target we're beating them to death with our bare hands
 		return active_hand
-	if(target.body_position == LYING_DOWN && owner.usable_legs)
+	if(should_kick(target) && target.body_position == LYING_DOWN && owner.usable_legs) // DARKPACK EDIT CHANGE
 		var/obj/item/bodypart/found_bodypart = owner.get_bodypart(IS_LEFT_INDEX(active_hand.held_index) ? BODY_ZONE_L_LEG : BODY_ZONE_R_LEG)
 		return found_bodypart || active_hand
 	return active_hand
+
+// DARKPACK EDIT ADD START
+/obj/item/organ/brain/proc/should_kick(mob/living/carbon/human/target)
+	var/obj/item/bodypart/arm/active_hand = owner.get_active_hand()
+	var/obj/item/bodypart/leg/active_leg = owner.get_bodypart(IS_LEFT_INDEX(active_hand.held_index) ? BODY_ZONE_L_LEG : BODY_ZONE_R_LEG)
+	if(!active_hand)
+		return TRUE
+	if(!active_leg)
+		return FALSE
+	// Now lets acctually compare them
+	if(active_hand.attack_type == AGGRAVATED)
+		return FALSE // AGG damage is gonna almost always be better dps..
+	if(active_hand.atk_effect == ATTACK_EFFECT_CLAW)
+		return FALSE // Claws get an extra bonus dice compared to kicking
+	return TRUE // Otherwise, kicking is PROBALLY better as it gets a +1 bonus to damage compared to punches.
+// DARKPACK EDIT ADD END
 
 /// Brains REALLY like ghosting people. we need special tricks to avoid that, namely removing the old brain with no_id_transfer
 /obj/item/organ/brain/replace_into(mob/living/carbon/new_owner)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -811,7 +811,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		attack_roll_type = /datum/storyteller_roll/attack/kick
 		damage_roll_type = /datum/storyteller_roll/damage/kick
 		damage_bonus_dice++
-	else if(atk_effect == ATTACK_EFFECT_CLAW) // Still missing agg damage...
+	else if(atk_effect == ATTACK_EFFECT_CLAW)
 		attack_roll_type = /datum/storyteller_roll/attack/claw
 		damage_roll_type = /datum/storyteller_roll/damage/claw
 		damage_bonus_dice += 2


### PR DESCRIPTION

## About The Pull Request
Primarly, dont kick someone if you have claws because it hurts your dps.
## Why It's Good For The Game
Someone being downed hurting your dps is counterintuitive.
## Changelog
:cl:
balance: Claws are prefered to kicking
fix: Claws get intended bonus dice on basic mobs
/:cl:
