### PR TITLE
You cant jump while prone

### DIFF
--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -56,6 +56,9 @@
 	if(HAS_TRAIT(jumper, TRAIT_FLOORED))
 		return
 
+	if(jumper.body_position == LYING_DOWN)
+		return
+
 	if(jumper.buckled)
 		return
 


### PR DESCRIPTION

## About The Pull Request
Yea
## Why It's Good For The Game
Shooting forward like a torpedo from a prone position is silly
## Changelog
:cl:
balance: You can no longer jump while lying down
/:cl:
