### PR TITLE
Werewolf forms are considered "large"

### DIFF
--- a/modular_darkpack/modules/cars/code/car.dm
+++ b/modular_darkpack/modules/cars/code/car.dm
@@ -476,20 +476,20 @@
 	if(istype(bumped_atom, /mob/living))
 		var/mob/living/hit_mob = bumped_atom
 		switch(hit_mob.mob_size)
-			if(MOB_SIZE_HUGE) 	//gangrel warforms, werewolves, bears, ppl with fortitude
+			if(MOB_SIZE_HUGE) // zulo form
 				playsound(src, 'modular_darkpack/modules/cars/sounds/bump.ogg', 75, TRUE)
 				speed_in_pixels = 0
 				COOLDOWN_START(src, impact_delay, 2 SECONDS)
 				hit_mob.Paralyze(1 SECONDS)
-			if(MOB_SIZE_LARGE)	//ppl with fat bodytype
+			if(MOB_SIZE_LARGE) // gangrel warforms, werewolves, bears
 				playsound(src, 'modular_darkpack/modules/cars/sounds/bump.ogg', 60, TRUE)
 				speed_in_pixels = round(speed_in_pixels * 0.35)
 				hit_mob.Knockdown(1 SECONDS)
-			if(MOB_SIZE_SMALL)	//small animals
+			if(MOB_SIZE_SMALL) //small animals
 				playsound(src, 'modular_darkpack/modules/cars/sounds/bump.ogg', 40, TRUE)
 				speed_in_pixels = round(speed_in_pixels * 0.75)
 				hit_mob.Knockdown(1 SECONDS)
-			else				//everything else
+			else //everything else
 				playsound(src, 'modular_darkpack/modules/cars/sounds/bump.ogg', 50, TRUE)
 				speed_in_pixels = round(speed_in_pixels * 0.5)
 				hit_mob.Knockdown(1 SECONDS)

--- a/modular_darkpack/modules/powers/code/discipline/protean/beast_form.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/beast_form.dm
@@ -55,7 +55,7 @@
 	icon_state = "gangrel_f"
 	icon_living = "gangrel_f"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	mob_size = MOB_SIZE_HUGE
+	mob_size = MOB_SIZE_LARGE
 	speed = -0.4
 	maxHealth = 275
 	health = 275

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
@@ -24,6 +24,8 @@
 	species_language_holder = /datum/language_holder/garou
 	var/mob_pixel_w
 	var/mob_pixel_z
+	/// If declared Will override the mob size.
+	var/mob_size_override
 	/// Stats added and removed upon gaining the species
 	var/list/form_bonus_stats = list()
 	/// Dice roll difficulty required to shift into this form
@@ -48,12 +50,18 @@
 
 	human_who_gained_species.add_offsets(type, w_add = mob_pixel_w, z_add = mob_pixel_z)
 
+	if(mob_size_override)
+		human_who_gained_species.mob_size = mob_size_override
+
 	add_buffs(human_who_gained_species)
 
 /datum/species/human/shifter/on_species_loss(mob/living/carbon/human/human, datum/species/new_species, pref_load)
 	. = ..()
 	if(speed_mod)
 		human.remove_movespeed_modifier(speed_mod)
+
+	if(mob_size_override)
+		human.mob_size == human::mob_size
 
 	human.remove_offsets(type)
 
@@ -140,6 +148,7 @@
 /datum/species/human/shifter/bestial
 	name = "bestial form"
 	id = SPECIES_FERA_BESTIAL
+	mob_size_override = MOB_SIZE_LARGE
 	form_bonus_stats = list(
 		STAT_STRENGTH = 2,
 		STAT_STAMINA = 2,
@@ -215,6 +224,8 @@
 
 	visible_gender_override = "beast"
 
+	mob_pixel_w = -8
+	mob_size_override = MOB_SIZE_LARGE
 	form_bonus_stats = list(
 		STAT_STRENGTH = 4,
 		STAT_STAMINA = 3,
@@ -222,7 +233,6 @@
 		STAT_MANIPULATION = -3,
 		// STAT_APPEARANCE = 0 // NOT YET SUPPORTED
 	)
-	mob_pixel_w = -8
 	custom_body_render = TRUE
 	custom_damage_render = TRUE
 	fallback_icon = 'modular_darkpack/modules/werewolf_the_apocalypse/icons/garou_forms/crinos.dmi'
@@ -256,6 +266,9 @@
 
 	visible_gender_override = "beast"
 
+	mob_pixel_w = -16
+	mob_pixel_z = -8
+	mob_size_override = MOB_SIZE_LARGE
 	form_bonus_stats = list(
 		STAT_STRENGTH = 3,
 		STAT_STAMINA = 3,
@@ -263,8 +276,6 @@
 		STAT_MANIPULATION = -3,
 	)
 	shift_difficulty = 7
-	mob_pixel_w = -16
-	mob_pixel_z = -8
 	custom_body_render = TRUE
 	custom_damage_render = TRUE
 	fallback_icon = 'modular_darkpack/modules/werewolf_the_apocalypse/icons/garou_forms/hispo.dmi'

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
@@ -24,7 +24,7 @@
 	species_language_holder = /datum/language_holder/garou
 	var/mob_pixel_w
 	var/mob_pixel_z
-	/// If declared Will override the mob size.
+	/// If declared will override the mob size.
 	var/mob_size_override
 	/// Stats added and removed upon gaining the species
 	var/list/form_bonus_stats = list()

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
@@ -148,7 +148,6 @@
 /datum/species/human/shifter/bestial
 	name = "bestial form"
 	id = SPECIES_FERA_BESTIAL
-	mob_size_override = MOB_SIZE_LARGE
 	form_bonus_stats = list(
 		STAT_STRENGTH = 2,
 		STAT_STAMINA = 2,
@@ -268,7 +267,6 @@
 
 	mob_pixel_w = -16
 	mob_pixel_z = -8
-	mob_size_override = MOB_SIZE_LARGE
 	form_bonus_stats = list(
 		STAT_STRENGTH = 3,
 		STAT_STAMINA = 3,

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
@@ -61,7 +61,7 @@
 		human.remove_movespeed_modifier(speed_mod)
 
 	if(mob_size_override)
-		human.mob_size == human::mob_size
+		human.mob_size = human::mob_size
 
 	human.remove_offsets(type)
 


### PR DESCRIPTION

## About The Pull Request
Makes the fera warform MOB_SIZE_LARGE
## Why It's Good For The Game
This doesn't TOO much, but a handful of things use this like preventing them from being put in closets.
You wont be able to fireman carry a warform
It makes them more resistant to shoves but i cant relocate the proc i saw for it. 

Decided to not to HUGE as even like a xeno queen is only considered large for how TG uses it.
## Changelog
:cl:
balance: fera warforms are considered large mobs 
balance: Gangrel forms are downgraded to large mobs instead of huge
/:cl:
