### PR TITLE
You can't handcuff dogs.

### DIFF
--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_species.dm
@@ -247,6 +247,7 @@
 		TRAIT_TRANSFORM_UPDATES_ICON,
 		TRAIT_FERAL_BITER,
 		TRAIT_SMALL_HANDS,
+		TRAIT_NO_CUFF,
 	)
 	veil_breaching_form = TRUE
 
@@ -289,6 +290,7 @@
 		TRAIT_TRANSFORM_UPDATES_ICON,
 		TRAIT_FERAL_BITER,
 		TRAIT_SMALL_HANDS,
+		TRAIT_NO_CUFF,
 	)
 
 	mutantbrain = /obj/item/organ/brain/fera


### PR DESCRIPTION

## About The Pull Request

Adds TRAIT_NO_CUFF to Lupus and Hispo forms. You can't handcuff a dog, they don't have hands. 


## Why It's Good For The Game

Removes accidental emergent behaviour

## Changelog
:cl:
balance: Made Lupus and Hispo unable to be handcuffed.
/:cl:
