### PR TITLE
Two fixes for the roll for fera shapeshifting

### DIFF
--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/transformation.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/transformation.dm
@@ -13,7 +13,8 @@
 		return
 	if(!(form_to_transform in transformation_list))
 		return
-	if(owner?.dna?.species?.type == form_to_transform)
+	var/datum/species/human/shifter/current_form = owner?.dna?.species
+	if(istype(current_form, form_to_transform))
 		return
 	if(!force && !COOLDOWN_FINISHED(src, transform_cd))
 		to_chat(owner, span_warning("Your shifting is on cooldown for one turn."))
@@ -37,7 +38,9 @@
 	// TODO: should accctually require an amount of successes equal to the forms your shifting through
 	if(requires_roll)
 		var/datum/storyteller_roll/fera_trans/transform_roll = new()
-		transform_roll.difficulty = form_to_transform::shift_difficulty
+		if(current_form)
+			transform_roll.difficulty = current_form.shift_difficulty
+			transform_roll.successes_needed = steps_between_forms(current_form.type, form_to_transform)
 		switch(transform_roll.st_roll(owner, owner, PRIMAL_URGE_PLACEHOLDER))
 			if(ROLL_SUCCESS)
 				pass()
@@ -60,6 +63,11 @@
 	SEND_SIGNAL(owner, COMSIG_MASQUERADE_VIOLATION)
 
 	addtimer(CALLBACK(src, PROC_REF(transform_finish), form_to_transform, time_to_transform), time_to_transform * 0.9)
+
+/datum/splat/werewolf/shifter/proc/steps_between_forms(datum/species/human/shifter/first_form, datum/species/human/shifter/second_form)
+	var/first_index = transformation_list.Find(first_form)
+	var/second_index = transformation_list.Find(second_form)
+	return abs(first_index - second_index)
 
 /datum/splat/werewolf/shifter/proc/revert_to_breed_form()
 	if(HAS_TRAIT(owner, TRAIT_METAMORPH))


### PR DESCRIPTION

## About The Pull Request
Number of successes required for Fera shifting is based on how many forms your swapping between. Was way easier then I told myself.
Feras's shift difficulty is based on the form your currently in rather then the one your turning into. Whoops. Misread the book or didnt acctually read the main section for this and just saw the "shift difficulty" numbers on glabro and hispo and stuff.
## Why It's Good For The Game
TTRPG accuracy.
Also means its more punishing to shift directly into crinos from human or lupus meaning we will prob see more of the intermediate forms
## Changelog
:cl:
balance: number of successes required for Fera shifting is based on how many forms your swapping between
fix: Feras's shift difficulty is based on the form your currently in rather then the one your turning into
/:cl:
