### PR TITLE
Reworks active potance effects

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
@@ -30,6 +30,9 @@
 		/datum/discipline_power/potence/five
 	)
 
+/datum/discipline_power/potence/post_gain()
+	owner.st_add_stat_mod(STAT_STRENGTH, level, "Potence")
+
 /datum/discipline_power/potence/one/activate()
 	. = ..()
 
@@ -40,8 +43,6 @@
 
 	owner.remove_status_effect(/datum/status_effect/potence/one)
 
-/datum/discipline_power/potence/one/post_gain()
-	owner.st_add_stat_mod(STAT_STRENGTH, 1, "Potence")
 
 //POTENCE 2
 /datum/discipline_power/potence/two
@@ -70,8 +71,6 @@
 	. = ..()
 	owner.remove_status_effect(/datum/status_effect/potence/two)
 
-/datum/discipline_power/potence/two/post_gain()
-	owner.st_add_stat_mod(STAT_STRENGTH, 2, "Potence")
 
 //POTENCE 3
 /datum/discipline_power/potence/three
@@ -100,8 +99,6 @@
 	. = ..()
 	owner.remove_status_effect(/datum/status_effect/potence/three)
 
-/datum/discipline_power/potence/three/post_gain()
-	owner.st_add_stat_mod(STAT_STRENGTH, 3, "Potence")
 
 //POTENCE 4
 /datum/discipline_power/potence/four
@@ -130,8 +127,6 @@
 	. = ..()
 	owner.remove_status_effect(/datum/status_effect/potence/four)
 
-/datum/discipline_power/potence/four/post_gain()
-	owner.st_add_stat_mod(STAT_STRENGTH, 4, "Potence")
 
 //POTENCE 5
 /datum/discipline_power/potence/five
@@ -159,6 +154,3 @@
 /datum/discipline_power/potence/five/deactivate()
 	. = ..()
 	owner.remove_status_effect(/datum/status_effect/potence/five)
-
-/datum/discipline_power/potence/five/post_gain()
-	owner.st_add_stat_mod(STAT_STRENGTH, 5, "Potence")

--- a/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
@@ -21,7 +21,7 @@
 	owner.st_add_stat_mod(STAT_STRENGTH, level, "Potence")
 
 /datum/discipline_power/potence/post_loss()
-	owner.st_remove_stat_mod(STAT_STRENGTH, "Potance")
+	owner.st_remove_stat_mod(STAT_STRENGTH, "Potence")
 
 /datum/discipline_power/potence/activate()
 	. = ..()

--- a/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
@@ -7,9 +7,34 @@
 /datum/discipline_power/potence
 	name = "Potence power name"
 	desc = "Potence power description"
+	abstract_type = /datum/discipline_power/potence
 
 	activate_sound = 'modular_darkpack/modules/powers/sounds/potence_activate.ogg'
 	deactivate_sound = 'modular_darkpack/modules/powers/sounds/potence_deactivate.ogg'
+
+	check_flags = DISC_CHECK_CAPABLE
+
+	toggled = TRUE
+	duration_length = 1 TURNS
+
+/datum/discipline_power/potence/post_gain()
+	owner.st_add_stat_mod(STAT_STRENGTH, level, "Potence")
+
+/datum/discipline_power/potence/post_loss()
+	owner.st_remove_stat_mod(STAT_STRENGTH, "Potance")
+
+/datum/discipline_power/potence/activate()
+	. = ..()
+
+	if(level <= 5)
+		var/max_level = min(discipline.level, 5)
+		owner.apply_status_effect(/datum/status_effect/potence, max_level)
+
+/datum/discipline_power/potence/deactivate()
+	. = ..()
+	if(level <= 5)
+		owner.remove_status_effect(/datum/status_effect/potence)
+
 
 //POTENCE 1
 /datum/discipline_power/potence/one
@@ -18,30 +43,12 @@
 
 	level = 1
 
-	check_flags = DISC_CHECK_CAPABLE
-
-	toggled = TRUE
-	duration_length = 2 TURNS
-
 	grouped_powers = list(
 		/datum/discipline_power/potence/two,
 		/datum/discipline_power/potence/three,
 		/datum/discipline_power/potence/four,
 		/datum/discipline_power/potence/five
 	)
-
-/datum/discipline_power/potence/post_gain()
-	owner.st_add_stat_mod(STAT_STRENGTH, level, "Potence")
-
-/datum/discipline_power/potence/one/activate()
-	. = ..()
-
-	owner.apply_status_effect(/datum/status_effect/potence/one)
-
-/datum/discipline_power/potence/one/deactivate()
-	. = ..()
-
-	owner.remove_status_effect(/datum/status_effect/potence/one)
 
 
 //POTENCE 2
@@ -51,25 +58,12 @@
 
 	level = 2
 
-	check_flags = DISC_CHECK_CAPABLE
-
-	toggled = TRUE
-	duration_length = 2 TURNS
-
 	grouped_powers = list(
 		/datum/discipline_power/potence/one,
 		/datum/discipline_power/potence/three,
 		/datum/discipline_power/potence/four,
 		/datum/discipline_power/potence/five
 	)
-
-/datum/discipline_power/potence/two/activate()
-	. = ..()
-	owner.apply_status_effect(/datum/status_effect/potence/two)
-
-/datum/discipline_power/potence/two/deactivate()
-	. = ..()
-	owner.remove_status_effect(/datum/status_effect/potence/two)
 
 
 //POTENCE 3
@@ -79,25 +73,12 @@
 
 	level = 3
 
-	check_flags = DISC_CHECK_CAPABLE
-
-	toggled = TRUE
-	duration_length = 2 TURNS
-
 	grouped_powers = list(
 		/datum/discipline_power/potence/one,
 		/datum/discipline_power/potence/two,
 		/datum/discipline_power/potence/four,
 		/datum/discipline_power/potence/five
 	)
-
-/datum/discipline_power/potence/three/activate()
-	. = ..()
-	owner.apply_status_effect(/datum/status_effect/potence/three)
-
-/datum/discipline_power/potence/three/deactivate()
-	. = ..()
-	owner.remove_status_effect(/datum/status_effect/potence/three)
 
 
 //POTENCE 4
@@ -107,25 +88,12 @@
 
 	level = 4
 
-	check_flags = DISC_CHECK_CAPABLE
-
-	toggled = TRUE
-	duration_length = 2 TURNS
-
 	grouped_powers = list(
 		/datum/discipline_power/potence/one,
 		/datum/discipline_power/potence/two,
 		/datum/discipline_power/potence/three,
 		/datum/discipline_power/potence/five
 	)
-
-/datum/discipline_power/potence/four/activate()
-	. = ..()
-	owner.apply_status_effect(/datum/status_effect/potence/four)
-
-/datum/discipline_power/potence/four/deactivate()
-	. = ..()
-	owner.remove_status_effect(/datum/status_effect/potence/four)
 
 
 //POTENCE 5
@@ -135,22 +103,9 @@
 
 	level = 5
 
-	check_flags = DISC_CHECK_CAPABLE
-
-	toggled = TRUE
-	duration_length = 2 TURNS
-
 	grouped_powers = list(
 		/datum/discipline_power/potence/one,
 		/datum/discipline_power/potence/two,
 		/datum/discipline_power/potence/three,
 		/datum/discipline_power/potence/four
 	)
-
-/datum/discipline_power/potence/five/activate()
-	. = ..()
-	owner.apply_status_effect(/datum/status_effect/potence/five)
-
-/datum/discipline_power/potence/five/deactivate()
-	. = ..()
-	owner.remove_status_effect(/datum/status_effect/potence/five)

--- a/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
@@ -53,8 +53,7 @@
 // This is bad and bypasses it being a strength dice thing.
 /datum/status_effect/potence/proc/apply_melee_modifier(mob/source, mob/M, mob/user, list/modifiers, list/attack_modifiers)
 	SIGNAL_HANDLER
-
-	attack_modifiers[FORCE_MULTIPLIER] += 0.4 * level
+	MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 1 + (0.4 * level))
 
 // Status effect ranks
 /datum/status_effect/potence/one

--- a/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
@@ -39,14 +39,9 @@
 
 	if (iscarbon(owner))
 		for (var/obj/item/bodypart/limb in affected_bodyparts)
-			limb.unarmed_damage_low -= 8 * level
-			limb.unarmed_damage_high -= 8 * level
 			limb.unarmed_attack_sound = initial(limb.unarmed_attack_sound)
 	else if (isbasicmob(owner))
 		var/mob/living/basic/basic_owner = owner
-
-		basic_owner.melee_damage_lower -= 8 * level
-		basic_owner.melee_damage_upper -= 8 * level
 		basic_owner.attack_sound = initial(basic_owner.attack_sound)
 
 	LAZYCLEARLIST(affected_bodyparts)
@@ -55,6 +50,7 @@
 
 	qdel(tackler)
 
+// This is bad and bypasses it being a strength dice thing.
 /datum/status_effect/potence/proc/apply_melee_modifier(mob/source, mob/M, mob/user, list/modifiers, list/attack_modifiers)
 	SIGNAL_HANDLER
 

--- a/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
@@ -19,15 +19,9 @@
 				continue
 
 			LAZYADD(affected_bodyparts, limb)
-
-			limb.unarmed_damage_low += 8 * level
-			limb.unarmed_damage_high += 8 * level
 			limb.unarmed_attack_sound = 'modular_darkpack/modules/powers/sounds/heavypunch.ogg'
 	else if (isbasicmob(owner))
 		var/mob/living/basic/basic_owner = owner
-
-		basic_owner.melee_damage_lower += 8 * level
-		basic_owner.melee_damage_upper += 8 * level
 		basic_owner.attack_sound = 'modular_darkpack/modules/powers/sounds/heavypunch.ogg'
 
 	RegisterSignal(owner, COMSIG_MOB_ITEM_ATTACK, PROC_REF(apply_melee_modifier))

--- a/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
@@ -3,9 +3,13 @@
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = null
 
-	var/level
+	var/level = 1
 	var/datum/component/tackler/tackler
 	var/list/obj/item/bodypart/affected_bodyparts
+
+/datum/status_effect/potence/on_creation(mob/living/new_owner, level)
+	src.level = level
+	. = ..()
 
 /datum/status_effect/potence/on_apply()
 	. = ..()
@@ -54,19 +58,3 @@
 /datum/status_effect/potence/proc/apply_melee_modifier(mob/source, mob/M, mob/user, list/modifiers, list/attack_modifiers)
 	SIGNAL_HANDLER
 	MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 1 + (0.4 * level))
-
-// Status effect ranks
-/datum/status_effect/potence/one
-	level = 1
-
-/datum/status_effect/potence/two
-	level = 2
-
-/datum/status_effect/potence/three
-	level = 3
-
-/datum/status_effect/potence/four
-	level = 4
-
-/datum/status_effect/potence/five
-	level = 5

--- a/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
@@ -12,6 +12,9 @@
 	if (!.)
 		return
 
+	owner.st_remove_stat_mod(STAT_STRENGTH, "Potence")
+	owner.st_add_auto_successes(STAT_STRENGTH, level, "Potence")
+
 	if (iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
 		for (var/obj/item/bodypart/limb as anything in carbon_owner.bodyparts)
@@ -30,6 +33,9 @@
 
 /datum/status_effect/potence/on_remove()
 	. = ..()
+
+	owner.st_remove_auto_successes(STAT_STRENGTH, "Potence")
+	owner.st_add_stat_mod(STAT_STRENGTH, level "Potence")
 
 	if (iscarbon(owner))
 		for (var/obj/item/bodypart/limb in affected_bodyparts)

--- a/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence_status_effect.dm
@@ -35,7 +35,7 @@
 	. = ..()
 
 	owner.st_remove_auto_successes(STAT_STRENGTH, "Potence")
-	owner.st_add_stat_mod(STAT_STRENGTH, level "Potence")
+	owner.st_add_stat_mod(STAT_STRENGTH, level, "Potence")
 
 	if (iscarbon(owner))
 		for (var/obj/item/bodypart/limb in affected_bodyparts)
@@ -50,7 +50,7 @@
 
 	qdel(tackler)
 
-// This is bad and bypasses it being a strength dice thing.
+// This is bad and bypasses it being a strength dice thing. Remove the second melee has any usage of strength for damage
 /datum/status_effect/potence/proc/apply_melee_modifier(mob/source, mob/M, mob/user, list/modifiers, list/attack_modifiers)
 	SIGNAL_HANDLER
 	MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 1 + (0.4 * level))

--- a/modular_darkpack/modules/powers/code/discipline/valeren.dm
+++ b/modular_darkpack/modules/powers/code/discipline/valeren.dm
@@ -496,4 +496,4 @@
 
 /datum/status_effect/vengeance_of_samiel/proc/apply_melee_modifier(mob/source, mob/M, mob/user, list/modifiers, list/attack_modifiers)
 	SIGNAL_HANDLER
-	attack_modifiers[FORCE_MULTIPLIER] += 0.4 * bonus
+	MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 1 + (0.4 * bonus))

--- a/modular_darkpack/modules/powers/code/discipline/valeren.dm
+++ b/modular_darkpack/modules/powers/code/discipline/valeren.dm
@@ -472,13 +472,9 @@
 			if (!istype(limb, /obj/item/bodypart/arm) && !istype(limb, /obj/item/bodypart/leg))
 				continue
 			LAZYADD(affected_bodyparts, limb)
-			limb.unarmed_damage_low += 8 * bonus
-			limb.unarmed_damage_high += 8 * bonus
 			limb.unarmed_attack_sound = pick(list('sound/items/weapons/cqchit2.ogg', 'sound/items/weapons/cqchit1.ogg')) // i know kung fu
 	else if (isbasicmob(owner))
 		var/mob/living/basic/basic_owner = owner
-		basic_owner.melee_damage_lower += 8 * bonus
-		basic_owner.melee_damage_upper += 8 * bonus
 		basic_owner.attack_sound = pick(list('sound/items/weapons/cqchit2.ogg', 'sound/items/weapons/cqchit1.ogg'))
 	RegisterSignal(owner, COMSIG_MOB_ITEM_ATTACK, PROC_REF(apply_melee_modifier))
 	tackler = owner.AddComponent(/datum/component/tackler, stamina_cost=0, base_knockdown = 1 SECONDS, range = 2 + bonus, speed = 1, skill_mod = 0, min_distance = 0)
@@ -490,13 +486,9 @@
 	owner.st_remove_stat_mod(STAT_BRAWL, bonus, "vengeance_of_samiel")
 	if (iscarbon(owner))
 		for (var/obj/item/bodypart/limb in affected_bodyparts)
-			limb.unarmed_damage_low -= 8 * bonus
-			limb.unarmed_damage_high -= 8 * bonus
 			limb.unarmed_attack_sound = initial(limb.unarmed_attack_sound)
 	else if (isbasicmob(owner))
 		var/mob/living/basic/basic_owner = owner
-		basic_owner.melee_damage_lower -= 8 * bonus
-		basic_owner.melee_damage_upper -= 8 * bonus
 		basic_owner.attack_sound = initial(basic_owner.attack_sound)
 	LAZYCLEARLIST(affected_bodyparts)
 	UnregisterSignal(owner, COMSIG_MOB_ITEM_ATTACK)

--- a/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
@@ -181,7 +181,7 @@
 			sucess_amount--
 		else
 			dice_text += span_danger("[get_dice_char(roll)]")
-	last_output_text += "[roll_result_text(roll_result(sucess_amount))] [dice_text]"
+	last_output_text += "[roll_result_text(roll_result(sucess_amount))] [span_slightly_larger(dice_text)]"
 	return sucess_amount
 
 /datum/storyteller_roll/proc/roll_result(sucess_amount)

--- a/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
@@ -48,9 +48,10 @@
 		return ROLL_FAILURE
 
 	var/dice_amount = calculate_used_dice(roller, bonus)
+	var/auto_success_amount = calculate_auto_successes(roller)
 	var/used_difficulty = calculate_used_difficulty(roller)
 
-	var/list/rolled_dice = roll_dice(dice_amount)
+	var/list/rolled_dice = roll_dice(dice_amount, auto_success_amount)
 
 	var/first_line = "[span_tooltip(show_rolling_with(roller, bonus), "[dice_amount] dice")] vs. difficulty [used_difficulty]."
 	if(successes_needed > 1)
@@ -109,8 +110,15 @@
 /datum/storyteller_roll/proc/calculate_used_dice(mob/living/roller, bonus = 0)
 	var/dice_amount = 0
 	for(var/stat_type in using_stats(roller))
-		dice_amount += roller.st_get_stat(stat_type)
+		dice_amount += roller.st_get_stat(stat_type, include_auto_successes = FALSE)
 	return dice_amount + bonus
+
+/datum/storyteller_roll/proc/calculate_auto_successes(mob/living/roller)
+	var/dice_amount = 0
+	for(var/stat_type in using_stats(roller))
+		var/datum/st_stat/given_stat = roller?.storyteller_stats[stat_type]
+		dice_amount += given_stat?.get_auto_success_score()
+	return dice_amount
 
 // Unused rn but can be used for overides of `using_stats()`
 /datum/storyteller_roll/proc/return_higher_stat(mob/living/roller, list/stats)
@@ -139,7 +147,7 @@
 		output += "+[bonus]"
 	return "Rolling [output]"
 
-/datum/storyteller_roll/proc/roll_dice(dice, sides = 10)
+/datum/storyteller_roll/proc/roll_dice(dice, auto_successes, sides = 10)
 	dice = max(dice, 1)
 	var/list/rolled_dice = list()
 	for(var/i in 1 to dice)
@@ -151,6 +159,8 @@
 				extra_dice++
 		for(var/i in 1 to extra_dice)
 			rolled_dice += rand(1, sides)
+	for(var/i in 1 to auto_successes)
+		rolled_dice += 11
 	return rolled_dice
 
 //Count the number of successes.
@@ -195,7 +205,8 @@
 				return span_bold(span_danger(("Botch -")))
 
 /datum/storyteller_roll/proc/get_dice_char(input)
-	var/static/list/dice_output = list("❶", "❷", "❸", "❹", "❺", "❻", "❼", "❽", "❾", "❿")
+	// "11" represents automatic successes
+	var/static/list/dice_output = list("❶", "❷", "❸", "❹", "❺", "❻", "❼", "❽", "❾", "❿", "☥")
 	return dice_output[input]
 	/* // This would require making it an assoc list and we dont every expect outside our given range.
 	// So if someone faces a runtime because of this just make it an actual assoc and deal with the micro preformace hit

--- a/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
@@ -53,7 +53,10 @@
 
 	var/list/rolled_dice = roll_dice(dice_amount, auto_success_amount)
 
-	var/first_line = "[span_tooltip(show_rolling_with(roller, bonus), "[dice_amount] dice")] vs. difficulty [used_difficulty]."
+	var/dice_used_text = "[dice_amount] dice"
+	if(auto_success_amount)
+		dice_used_text += " + [auto_success_amount] auto successes"
+	var/first_line = "[span_tooltip(show_rolling_with(roller, bonus), dice_used_text)] vs. difficulty [used_difficulty]."
 	if(successes_needed > 1)
 		first_line += " [successes_needed] successes needed."
 	last_output_text += span_notice(first_line)

--- a/modular_darkpack/modules/storyteller_stats/code/_st_stats.dm
+++ b/modular_darkpack/modules/storyteller_stats/code/_st_stats.dm
@@ -13,6 +13,8 @@
 	VAR_PROTECTED/score = 0
 	/// Temporary bonus score applied to this stat from various ingame sources.
 	VAR_PROTECTED/bonus_score = 0
+	/// Temporary bonus score applied to this stat from various ingame sources. These are directly added to results rather then added to dice pool
+	VAR_PROTECTED/auto_success_score = 0
 	/// The minimum score this stat can be.
 	var/min_score = 0
 	/// The maximum score this stat can be.
@@ -26,6 +28,8 @@
 	var/editable = TRUE
 	/// A dictionary of modifiers to this attribute.
 	var/list/modifiers = list()
+	/// A dictionary of auto success scores to this attribute.
+	var/list/auto_successes = list()
 	/// What score does this stat start out with at character creation.
 	var/starting_score = 0
 	/// How many points are in this stat category that the player can use. Used in abstract classes only.
@@ -35,16 +39,23 @@
 
 // Score
 
-/datum/st_stat/proc/get_score(include_bonus = TRUE)
+/datum/st_stat/proc/get_score(include_bonus = TRUE, include_auto_sucesses = TRUE)
 	SHOULD_NOT_OVERRIDE(TRUE)
 	if(include_bonus)
-		return score + bonus_score
+		if(include_auto_sucesses)
+			return score + bonus_score + auto_success_score
+		else
+			return score + bonus_score
 	else
 		return score
 
 /datum/st_stat/proc/get_bonus_score()
 	SHOULD_NOT_OVERRIDE(TRUE)
 	return bonus_score
+
+/datum/st_stat/proc/get_auto_success_score()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	return auto_success_score
 
 /datum/st_stat/proc/can_set_score(amount)
 	SHOULD_NOT_OVERRIDE(TRUE)
@@ -107,6 +118,24 @@
 	for(var/source in modifiers)
 		bonus_score += modifiers[source]
 	bonus_score = clamp(bonus_score, -max_score, 10)
+
+
+/datum/st_stat/proc/add_auto_successes(amount, source)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	LAZYSET(auto_successes, source, amount)
+	update_auto_successes()
+
+/datum/st_stat/proc/remove_auto_successes(source)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	LAZYREMOVE(auto_successes, source)
+	update_auto_successes()
+
+/datum/st_stat/proc/update_auto_successes()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	auto_success_score = initial(auto_success_score)
+	for(var/source in auto_successes)
+		auto_success_score += auto_successes[source]
+	auto_success_score = clamp(auto_success_score, 0, 10)
 
 // Points
 

--- a/modular_darkpack/modules/storyteller_stats/code/mob_affecting_adjustments/mob_procs.dm
+++ b/modular_darkpack/modules/storyteller_stats/code/mob_affecting_adjustments/mob_procs.dm
@@ -1,14 +1,14 @@
 /// Get a specific mob's stat from its stats list.
-/mob/living/proc/st_get_stat(stat_path, include_bonus)
+/mob/living/proc/st_get_stat(stat_path, include_bonus, include_auto_successes)
 	var/datum/st_stat/given_stat = storyteller_stats[stat_path]
-	return given_stat?.get_score(include_bonus)
+	return given_stat?.get_score(include_bonus, include_auto_successes)
 
 /// Wrapper for st_get_stat to reduce copypaste. Get a specific mob's stat from its stats list.
-/mob/living/proc/st_get_stats(list/stat_list, include_bonus)
+/mob/living/proc/st_get_stats(list/stat_list, include_bonus, include_auto_successes)
 	var/total_score = 0
 	for(var/stat_path in stat_list)
 		var/datum/st_stat/given_stat = storyteller_stats[stat_path]
-		total_score += given_stat?.get_score(include_bonus)
+		total_score += given_stat?.get_score(include_bonus, include_auto_successes)
 	return total_score
 
 /// Set a specific mob's stat from its stats list.
@@ -38,6 +38,19 @@
 /mob/living/proc/st_remove_stat_mod(stat_path, source)
 	var/datum/st_stat/given_stat = storyteller_stats[stat_path]
 	var/score = given_stat?.remove_stat_mod(source)
+	update_modifiers_from_stats()
+	return score
+
+
+/mob/living/proc/st_add_auto_successes(stat_path, amount, source)
+	var/datum/st_stat/given_stat = storyteller_stats[stat_path]
+	var/score = given_stat?.add_auto_successes(amount, source)
+	update_modifiers_from_stats()
+	return score
+
+/mob/living/proc/st_remove_auto_successes(stat_path, source)
+	var/datum/st_stat/given_stat = storyteller_stats[stat_path]
+	var/score = given_stat?.remove_auto_successes(source)
 	update_modifiers_from_stats()
 	return score
 


### PR DESCRIPTION

## About The Pull Request
Active potance is now mostly TTRPG accruate and its primary effect is converting potances strength dots directly into AUTO SUCCESSES (regardless of dot cast, which means all the actions now do the same thing. (investigate a flag for not adding some actions tbh)
Acctually a pretty massive buff to potance as it makes damage VERY consistent.

I was originally gonna tackle Vengeance of Samiel cause it could use some work but ATOMIZATION!!

I fixed the melee thing but its kinda due for scraping once melee is affected by strength

https://github.com/user-attachments/assets/9ea24806-ec32-44ac-bb96-ab3d41a6d617

As a refresher: V20 pg. 192
<img width="435" height="569" alt="image" src="https://github.com/user-attachments/assets/d8dc1517-b30e-4916-8492-82d29fd2f341" />


## Why It's Good For The Game
TTRPG accuracy. Makes brawl actually effected by potance.

## Changelog
:cl:
add: Adds support for automatic successes based on the TTRPG
code: Cleans up some of the code surrounding potance
balance: Kills some of the snowflaky effect of potance in favor of it granting automatic successes (TTRPG accuracy)
qol: Makes the dice unicode characters to show individual dice results a little larger
fix: Potance 1-2 no longer cripples melee damage and it now scales correctly with all dots.
/:cl:
