### PR TITLE
Lowers animalism mobs bloodpool

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/animalism.dm
+++ b/modular_darkpack/modules/powers/code/discipline/animalism.dm
@@ -138,6 +138,7 @@
 	melee_damage_lower = 3
 	melee_damage_upper = 8
 	obj_damage = 10
+	bloodpool = 2
 
 /mob/living/basic/mouse/vampire/summoned/Initialize(mapload)
 	AddElement(/datum/element/ai_retaliate)
@@ -153,6 +154,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 12
 	obj_damage = 15
+	bloodpool = 2
 
 /mob/living/basic/pet/cat/darkpack/summoned/Initialize(mapload)
 	. = ..()
@@ -176,6 +178,7 @@
 	attack_verb_simple = "bite"
 	attack_sound = 'modular_darkpack/modules/deprecated/sounds/dog.ogg'
 	random_wolf_color = FALSE
+	bloodpool = 2
 
 /mob/living/basic/pet/dog/wolf/summoned/Initialize(mapload)
 	. = ..()
@@ -192,6 +195,7 @@
 	obj_damage = 10
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
+	bloodpool = 2
 
 /mob/living/basic/bat/summoned/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

animalism as a whole needs a total rework that has the possibility for a gameplay loop (go out, animalism 1 an animal, get it as a summonable mob for animalism 3 or whatever it is, animalism 4/5 to frenzy/quell the beast?) but until then we need to tone down the bloodpools of these mobs as you can pretty nastily exploit the fact that they are bloodpool = 5 to never have to feed off humans, transforming into birds, flying to a roof, summoning a dog, then feeding off of it.

## Why It's Good For The Game

making feeding off animals harder

## Changelog

:cl:

balance: animalism mobs now have bloodpool = 2

/:cl:


