### PR TITLE
Fixing Thaumaturgy 4 Corpse Bug

### DIFF
--- a/modular_darkpack/modules/paths/code/conjured_items.dm
+++ b/modular_darkpack/modules/paths/code/conjured_items.dm
@@ -54,7 +54,7 @@
 	desc = "Your hand burns with supernatural fire."
 	icon_state = "flame"
 	inhand_icon_state = "flame"
-	force = 25
+	force = 15
 	fancy = FALSE
 
 // Levinbolt items
@@ -63,7 +63,7 @@
 	desc = "Your arm surges with electricity!"
 	icon_state = "illuminate"
 	inhand_icon_state = "illuminate"
-	force = 15
+	force = 10
 	light_range = 2
 	light_power = 1
 	light_color = COLOR_WHITE

--- a/modular_darkpack/modules/powers/code/discipline/thaumaturgy/path_of_blood.dm
+++ b/modular_darkpack/modules/powers/code/discipline/thaumaturgy/path_of_blood.dm
@@ -239,7 +239,7 @@
 
 	level = 4
 
-	vitae_cost = 0 //Since 1 success should give one vitae, balancing.
+	vitae_cost = 1
 	effect_sound = 'sound/effects/magic/enter_blood.ogg'
 	range = 8 // Within 50 feet (15 meters).
 	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_TORPORED | DISC_CHECK_SEE | DISC_CHECK_DIRECT_SEE // The subject must be visible to the thaumaturge
@@ -267,6 +267,8 @@
 		var/blood_gained = blood_taken * max(1, target.bloodquality-1)
 		owner.adjust_blood_pool(blood_gained)
 	else
+		if(!target.bloodpool || !target.blood_volume)
+			return
 		var/blood_coefficient = (5 / target.bloodpool)
 		// DARKPACK TODO - reimplement quirks -- potent blood
 		/*
@@ -277,6 +279,7 @@
 		target.blood_volume = max (0, (target.blood_volume - (blood_taken * (70*blood_coefficient))))
 
 		var/blood_gained = blood_taken * max(1, target.bloodquality - 1)
+		target.adjust_blood_pool(-blood_gained)
 		owner.adjust_blood_pool(blood_gained)
 
 //------------------------------------------------------------------------------------------------
@@ -287,7 +290,7 @@
 	desc = "Boil your target's blood in their body, killing almost anyone."
 
 	level = 5
-	range = 1 //The Kindred must touch the subject
+	range = 1
 	check_flags = DISC_CHECK_FREE_HAND | DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_TORPORED
 	target_type = TARGET_MOB | TARGET_SELF
 	aggravating = TRUE


### PR DESCRIPTION
## About The Pull Request

when using thaumaturgy 4 you could get infinite blood from anything non-kindred or ghoul splat because the else clause didn't adjust target's bloodpool (the clamped value for how much blood is taken) because what it did adjust was blood volume, expecting the target to collapse from bloodloss (like a random npc human)

however, when theyre a dead body, you could just continue to sap a million bloodpoints from them, forever

same with blood guardian summons for tremeres, they cost 5 bp, you could summon one, and just sap infinity bloodpoints from them because their bloodpool isn't adjusted

## Why It's Good For The Game

fix

## Changelog

:cl:

fix: fixes Thaumaturgy 4 not incrementing the target's bloodpool
fix: Thaumaturgy 4 Theft of Vitae now costs 1 bloodpoint
balance: lowers Lure of Flames and Levinbolt 'palm of flame'-type ability's damage from 25 burn (50 against kindred) per click to 15 burn (30 against kindred), 20 for 'candle' and 'illuminate'

/:cl:

