### PR TITLE
Fera transformations shread clothing

### DIFF
--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/transformation.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/transformation.dm
@@ -53,6 +53,9 @@
 
 	// owner.Stun(time_to_transform, ignore_canstun = TRUE)
 
+	for(var/obj/item/clothing/equipped in owner.get_equipped_items(INCLUDE_ABSTRACT))
+		equipped.take_damage(rand(25, 50), sound_effect = FALSE)
+
 	var/matrix/ntransform = matrix(owner.transform)
 	ntransform.Scale(1.1, 1.1)
 	animate(owner, transform = ntransform, color = "#000000", time = time_to_transform * 0.9)


### PR DESCRIPTION

## About The Pull Request
Makes it so transforming does 25-50 (cloths have 250 integ) to all your clothing when you shapeshift
## Why It's Good For The Game
Even glabro's transformation is meant to tear and rip clothing and most art depicts them like that.
## Changelog
:cl:
balance: Fera transformations damage worn clothing
/:cl:
