### PR TITLE
Adds Maximum Age Limit

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -18,9 +18,9 @@
 /// Checks for character whitelist.
 #define JOB_UNAVAILABLE_WHITELIST 10
 /// Checks for character kindred age. (Minium age)
-#define JOB_UNAVAILABLE_KINDRED_AGE 11
+#define JOB_UNAVAILABLE_KINDRED_AGE_MIN 11
 /// Checks for character kindred age. (Maximum age)
-#define JOB_UNAVAILABLE_KINDRED_AGE_OLD 12
+#define JOB_UNAVAILABLE_KINDRED_AGE_MAX 12
 /// Checks for character kindred generation.
 #define JOB_UNAVAILABLE_KINDRED_GENERATION 13
 /// Checks for character clan.

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -17,14 +17,16 @@
 #define JOB_UNAVAILABLE_SPLAT_SLOTS 9
 /// Checks for character whitelist.
 #define JOB_UNAVAILABLE_WHITELIST 10
-/// Checks for character kindred age.
+/// Checks for character kindred age. (Minium age)
 #define JOB_UNAVAILABLE_KINDRED_AGE 11
+/// Checks for character kindred age. (Maximum age)
+#define JOB_UNAVAILABLE_KINDRED_AGE_OLD 12
 /// Checks for character kindred generation.
-#define JOB_UNAVAILABLE_KINDRED_GENERATION 12
+#define JOB_UNAVAILABLE_KINDRED_GENERATION 13
 /// Checks for character clan.
-#define JOB_UNAVAILABLE_KINDRED_CLAN 13
-#define JOB_UNAVAILABLE_FERA_TRIBE 14
-#define JOB_UNAVAILABLE_FERA_AUSPICE 15
+#define JOB_UNAVAILABLE_KINDRED_CLAN 14
+#define JOB_UNAVAILABLE_FERA_TRIBE 15
+#define JOB_UNAVAILABLE_FERA_AUSPICE 16
 
 // DARKPACK EDIT ADD END
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -139,9 +139,9 @@
 			return "[jobtitle] doesn't have any free splat slots for you. (This can include human)"
 		if(JOB_UNAVAILABLE_WHITELIST)
 			return "You aren't whitelisted for [jobtitle]."
-		if(JOB_UNAVAILABLE_KINDRED_AGE)
+		if(JOB_UNAVAILABLE_KINDRED_AGE_MIN)
 			return "Your character is too young for [jobtitle]."
-		if(JOB_UNAVAILABLE_KINDRED_AGE_OLD)
+		if(JOB_UNAVAILABLE_KINDRED_AGE_MAX)
 			return "Your character is too old for [jobtitle]."
 		if(JOB_UNAVAILABLE_KINDRED_GENERATION)
 			return "Your character's generation is too high for [jobtitle]."

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -141,6 +141,8 @@
 			return "You aren't whitelisted for [jobtitle]."
 		if(JOB_UNAVAILABLE_KINDRED_AGE)
 			return "Your character is too young for [jobtitle]."
+		if(JOB_UNAVAILABLE_KINDRED_AGE_OLD)
+			return "Your character is too old for [jobtitle]."
 		if(JOB_UNAVAILABLE_KINDRED_GENERATION)
 			return "Your character's generation is too high for [jobtitle]."
 		if(JOB_UNAVAILABLE_KINDRED_CLAN)

--- a/modular_darkpack/modules/jobs/code/_job_assignment.dm
+++ b/modular_darkpack/modules/jobs/code/_job_assignment.dm
@@ -55,7 +55,7 @@
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_AGE, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 		return JOB_UNAVAILABLE_KINDRED_AGE
 
-	if((player_client.prefs.read_preference(/datum/preference/numeric/immortal_age) > possible_job.maximum_immortal_age))
+	if((!isnull(possible_job.maximum_immortal_age) && (player_client.prefs.read_preference(/datum/preference/numeric/immortal_age) > possible_job.maximum_immortal_age)))
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_AGE_OLD, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 		return JOB_UNAVAILABLE_KINDRED_AGE_OLD
 

--- a/modular_darkpack/modules/jobs/code/_job_assignment.dm
+++ b/modular_darkpack/modules/jobs/code/_job_assignment.dm
@@ -52,12 +52,12 @@
 
 /datum/controller/subsystem/job/proc/check_kindred_prefs(client/player_client, mob/dead/new_player/player, datum/job/possible_job, debug_prefix = "", add_job_to_log = FALSE)
 	if((player_client.prefs.read_preference(/datum/preference/numeric/immortal_age) < possible_job.minimum_immortal_age))
-		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_AGE, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
-		return JOB_UNAVAILABLE_KINDRED_AGE
+		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_AGE_MIN, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
+		return JOB_UNAVAILABLE_KINDRED_AGE_MIN
 
 	if((!isnull(possible_job.maximum_immortal_age) && (player_client.prefs.read_preference(/datum/preference/numeric/immortal_age) > possible_job.maximum_immortal_age)))
-		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_AGE_OLD, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
-		return JOB_UNAVAILABLE_KINDRED_AGE_OLD
+		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_AGE_MAX, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
+		return JOB_UNAVAILABLE_KINDRED_AGE_MAX
 
 	if((player_client.prefs.read_preference(/datum/preference/numeric/generation) > possible_job.minimal_generation))
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_GENERATION, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")

--- a/modular_darkpack/modules/jobs/code/_job_assignment.dm
+++ b/modular_darkpack/modules/jobs/code/_job_assignment.dm
@@ -55,6 +55,10 @@
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_AGE, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 		return JOB_UNAVAILABLE_KINDRED_AGE
 
+	if((player_client.prefs.read_preference(/datum/preference/numeric/immortal_age) > possible_job.maximum_immortal_age))
+		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_AGE_OLD, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
+		return JOB_UNAVAILABLE_KINDRED_AGE_OLD
+
 	if((player_client.prefs.read_preference(/datum/preference/numeric/generation) > possible_job.minimal_generation))
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_KINDRED_GENERATION, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 		return JOB_UNAVAILABLE_KINDRED_GENERATION

--- a/modular_darkpack/modules/jobs/code/_jobs.dm
+++ b/modular_darkpack/modules/jobs/code/_jobs.dm
@@ -15,7 +15,7 @@
 	var/minimal_masquerade = 0
 	/// Character must be at least this age (in years) since embrace (chronological_age - age) to join as role.
 	var/minimum_immortal_age = 0
-	/// Character must not be over this age (in years) since embrace (chronological_age - age) to join as role. (Defaults 1000, lower to desired age.)
+	/// Character must not be over this age (in years) since embrace (chronological_age - age) to join as role. (Defaults null, set to desired age.)
 	var/maximum_immortal_age = null
 	///List of Clans that are allowed to do this job.
 	var/list/allowed_clans

--- a/modular_darkpack/modules/jobs/code/_jobs.dm
+++ b/modular_darkpack/modules/jobs/code/_jobs.dm
@@ -15,6 +15,8 @@
 	var/minimal_masquerade = 0
 	/// Character must be at least this age (in years) since embrace (chronological_age - age) to join as role.
 	var/minimum_immortal_age = 0
+	/// Character must not be over this age (in years) since embrace (chronological_age - age) to join as role. (Defaults 1000, lower to desired age.)
+	var/maximum_immortal_age = 1000
 	///List of Clans that are allowed to do this job.
 	var/list/allowed_clans
 	///List of Clans that are disallowed to do this job.

--- a/modular_darkpack/modules/jobs/code/_jobs.dm
+++ b/modular_darkpack/modules/jobs/code/_jobs.dm
@@ -16,7 +16,7 @@
 	/// Character must be at least this age (in years) since embrace (chronological_age - age) to join as role.
 	var/minimum_immortal_age = 0
 	/// Character must not be over this age (in years) since embrace (chronological_age - age) to join as role. (Defaults 1000, lower to desired age.)
-	var/maximum_immortal_age = 1000
+	var/maximum_immortal_age = null
 	///List of Clans that are allowed to do this job.
 	var/list/allowed_clans
 	///List of Clans that are disallowed to do this job.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This was requested over on TFN, I saw players and staff both discussing this and got the go-ahead from lore staff to add a simple support for it.

I did not change any values as this is meant to be used by the individual servers if they choose to use this support. This I believe was intended for certain roles, i.e stripper, from being played by old immortal vampires. We can't have Dark Age strippers, sigh.....

Shoved this on hound purely to show it works, stops joining as the role akin to how generation or being too young does. (Hound file not harmed in the making of this PR.)
<img width="311" height="56" alt="image" src="https://github.com/user-attachments/assets/497f3b7e-e535-4f99-977f-ab833ad598b6" />

## Why It's Good For The Game

Overall just adds support that TFN and other downstreams may make use of to limit lower-run society jobs from elder vampires.  Pretty light-weight since the max age is set above what you should be able to choose for a vampire anyway without admin interference.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds maximum immortal age variable for jobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
