### PR TITLE
ghoul auras fix

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/auspex/aura_component.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/aura_component.dm
@@ -295,6 +295,7 @@
 		hsv_color_value[2] = hsv_color_value[2] * 0.7 // Reduce saturation for ghouls
 		aura_smoke_image.color = hsv2rgb(hsv_color_value)
 		aura_classic_image.icon_state = "old_aura_ghoul"
+		aura_smoke_image.alpha = 50
 
 	if(isavatar(parent_mob) || isobserver(parent_mob))
 		holder.opacity = holder.opacity * 0.5


### PR DESCRIPTION

## About The Pull Request

fixes the opacity issue on ghoul sprites. the smoke alpha was not being reapplied after setting the color values

## Changelog
:cl:
fix: Ghoul auras are no longer fully opaque
/:cl:
