### PR TITLE
Necro 3 doesnt leave uncleanable bones

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/necromancy.dm
+++ b/modular_darkpack/modules/powers/code/discipline/necromancy.dm
@@ -62,6 +62,7 @@
 		return
 
 	ADD_TRAIT(owner, TRAIT_GHOST_VISION, NECROMANCY_TRAIT)
+	ADD_TRAIT(owner, TRAIT_LOCAL_SIXTHSENSE, NECROMANCY_TRAIT)
 	owner.update_sight()
 
 	to_chat(owner, span_notice("You peek beyond the Shroud."))
@@ -70,6 +71,7 @@
 	. = ..()
 
 	REMOVE_TRAIT(owner, TRAIT_GHOST_VISION, NECROMANCY_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_LOCAL_SIXTHSENSE, NECROMANCY_TRAIT)
 	owner.update_sight()
 
 	to_chat(owner, span_warning("Your vision returns to the mortal realm."))
@@ -96,22 +98,9 @@
 
 /datum/discipline_power/necromancy/ethereal_horde/activate()
 	. = ..()
-
-	//var/limit = 2 + owner.st_get_stat(STAT_LEADERSHIP)
-	//var/diff = limit - length(owner.beastmaster)
-	//if(diff <= 0)
-		//to_chat(owner, span_warning("The vitae cools - you cannot extend your will to any more followers."))
-		//return
-
 	owner.visible_message(span_warning("Wailing shades step forth from [owner]'s shadow."))
 	owner.add_beastmaster_minion(/mob/living/basic/beastmaster/giovanni_zombie/level1)
 	owner.add_beastmaster_minion(/mob/living/basic/beastmaster/giovanni_zombie/level1)
-	//if(diff != 1)
-		//var/mob/living/simple_animal/hostile/beastmaster/giovanni_zombie/zombie2 = new /mob/living/simple_animal/hostile/beastmaster/giovanni_zombie/level1(owner.loc)
-		//zombie2.my_creator = owner
-		//owner.beastmaster |= zombie2
-		//zombie2.beastmaster_owner = owner
-
 
 //ASHES TO ASHES
 /datum/discipline_power/necromancy/ashes_to_ashes
@@ -164,7 +153,7 @@
 		owner.visible_message(span_warning("[owner] motions towards [target]."))
 		dusted.visible_message(span_danger("[target]'s body dissolves into dust before your very eyes!"))
 		to_chat(owner, span_warning("You've absorbed the body's residual lifeforce. You gain <b>BLOOD</b> and <b>A SOUL</b>."))
-		dusted.dust()
+		dusted.dust(just_ash = TRUE)
 		owner.adjust_blood_pool(2) // corpses = 2 blood
 		if(isliving(owner))
 			owner.collected_souls += 1
@@ -286,11 +275,7 @@
 
 /datum/discipline_power/necromancy/shambling_horde/activate(mob/living/target)
 	. = ..()
-	//var/limit = 2 + owner.st_get_stat(STAT_LEADERSHIP)
-	//var/diff = limit - length(owner.beastmaster)
 	if (target.stat == DEAD)
-			//to_chat(owner, span_warning("The vitae cools - you cannot extend your will to any more followers."))
-			//return
 		owner.visible_message(span_warning("[owner] gestures over [target]'s carcass."))
 		target.visible_message(span_danger("[target] twitches and rises, puppeteered by an invisible force."))
 		if(iscarbon(target))

--- a/modular_darkpack/modules/powers/code/discipline/necromancy.dm
+++ b/modular_darkpack/modules/powers/code/discipline/necromancy.dm
@@ -62,7 +62,6 @@
 		return
 
 	ADD_TRAIT(owner, TRAIT_GHOST_VISION, NECROMANCY_TRAIT)
-	ADD_TRAIT(owner, TRAIT_LOCAL_SIXTHSENSE, NECROMANCY_TRAIT)
 	owner.update_sight()
 
 	to_chat(owner, span_notice("You peek beyond the Shroud."))
@@ -71,7 +70,6 @@
 	. = ..()
 
 	REMOVE_TRAIT(owner, TRAIT_GHOST_VISION, NECROMANCY_TRAIT)
-	REMOVE_TRAIT(owner, TRAIT_LOCAL_SIXTHSENSE, NECROMANCY_TRAIT)
 	owner.update_sight()
 
 	to_chat(owner, span_warning("Your vision returns to the mortal realm."))


### PR DESCRIPTION
## About The Pull Request
necro 3 was leaving uncleanable bones so bones would be permanently left behind across the map by necromancers

## Why It's Good For The Game

bugfix

## Changelog

:cl:

fix: necro 3 no longer permanently leaves bones

/:cl:

