### PR TITLE
Transformer repair roll botch fix

### DIFF
--- a/modular_darkpack/modules/electricity/code/fusebox.dm
+++ b/modular_darkpack/modules/electricity/code/fusebox.dm
@@ -101,7 +101,7 @@ GLOBAL_LIST_EMPTY(fuseboxes)
 				return ITEM_INTERACT_SUCCESS
 			if(repair_amount <= 0)
 				user.electrocute_act(50, src, siemens_coeff = 1, flags = NONE)
-
+				repairing = FALSE
 	return NONE
 
 // transformers (another type of fusebox)


### PR DESCRIPTION

## About The Pull Request
Transformers were unfixable if someone botched the roll due to an oversight, this PR should fix that 
## Changelog
:cl:
fix: fixed transformers being unrepairable upon failing the roll
:cl: