### PR TITLE
Adds Berry Juice to the Soda Dispenser + Drink recipe tweaks

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
+++ b/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
@@ -156,8 +156,9 @@
 
 /datum/chemical_reaction/drink/threemileisland
 	results = list(/datum/reagent/consumable/ethanol/threemileisland = 10)
-	required_reagents = list(/datum/reagent/consumable/ethanol/longislandicedtea = 10, /datum/reagent/uranium = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/longislandicedtea = 10, /datum/reagent/consumable/ethanol/atomicbomb = 1) // DARKPACK EDIT CHANGE
 	reaction_tags = REACTION_TAG_DRINK | REACTION_TAG_EASY | REACTION_TAG_OTHER
+	mix_message = "Is that a geiger counter going off?" // DARKPACK EDIT ADD
 
 /datum/chemical_reaction/drink/whiskeysoda
 	results = list(/datum/reagent/consumable/ethanol/whiskeysoda = 3)
@@ -181,7 +182,8 @@
 
 /datum/chemical_reaction/drink/manhattan_proj
 	results = list(/datum/reagent/consumable/ethanol/manhattan_proj = 10)
-	required_reagents = list(/datum/reagent/consumable/ethanol/manhattan = 10, /datum/reagent/uranium = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/manhattan = 10, /datum/reagent/consumable/ethanol/atomicbomb = 1) // DARKPACK EDIT CHANGE
+	mix_message = "Smells like Death, the Destroyer of Worlds." // DARKPACK EDIT ADD
 
 /datum/chemical_reaction/drink/vodka_tonic
 	results = list(/datum/reagent/consumable/ethanol/vodkatonic = 3)
@@ -197,7 +199,7 @@
 
 /datum/chemical_reaction/drink/singulo
 	results = list(/datum/reagent/consumable/ethanol/singulo = 10)
-	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 5, /datum/reagent/liquid_dark_matter = 1, /datum/reagent/consumable/ethanol/wine = 5)
+	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 5, /datum/reagent/toxin/mindbreaker = 1, /datum/reagent/consumable/ethanol/wine = 5) // DARKPACK EDIT CHANGE
 
 /datum/chemical_reaction/drink/alliescocktail
 	results = list(/datum/reagent/consumable/ethanol/alliescocktail = 2)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -609,6 +609,7 @@
 		/datum/reagent/consumable/menthol,
 		/datum/reagent/consumable/orangejuice,
 		/datum/reagent/consumable/pineapplejuice,
+		/datum/reagent/consumable/berryjuice, // DARKPACK EDIT ADD
 		/datum/reagent/consumable/pwr_game,
 		/datum/reagent/consumable/shamblers,
 		/datum/reagent/consumable/spacemountainwind,


### PR DESCRIPTION

## About The Pull Request
Upstreaming of https://github.com/The-Final-Nights/The-Final-Nights-Rebase/pull/250
## Changelog
:cl:
add: Added Berry Juice to Dispenser
balance: Replacing Uranium with Atomic Bomb, and LDM with Mindbreaker
/:cl:
