### PR TITLE
Firearms Stat Version 1.1 (Patched, Updated, Re-Released)

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -613,8 +613,20 @@
 		recoil_roll = new()
 
 	if(COOLDOWN_FINISHED(src, recoil_skill_check))
+		for(var/obj/item/gun/gun in user.held_items)
+			if(gun == src || gun.weapon_weight >= WEAPON_MEDIUM)
+				continue
+			else if(can_trigger_gun(user, akimbo_usage = TRUE))
+				recoil_roll.difficulty += 1	//Akimboing gains +1 difficulty
+		if(firing_burst == TRUE)
+			recoil_roll.difficulty += 1	//Bursts gains +1 difficulty
+		var/datum/component/automatic_fire/automatic_check = src.GetComponent(/datum/component/automatic_fire)
+		if(automatic_check)
+			recoil_roll.difficulty += 2	//Full-auto gains +2 difficulty
+
 		var/recoil_reduction = recoil_roll.st_roll(user, src)
 		recoil = max(initial(recoil) - recoil_reduction, 0)
+		spread = max(initial(spread) - recoil_reduction, 0)
 		COOLDOWN_START(src, recoil_skill_check, 1 SCENES)
 	// DARKPACK EDIT ADD END
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -782,12 +782,6 @@
 	if (!log_override && firer && original && !do_not_log)
 		log_combat(firer, original, "fired at", src, "from [get_area_name(src, TRUE)]")
 			//note: mecha projectile logging is handled in /obj/item/mecha_parts/mecha_equipment/weapon/action(). try to keep these messages roughly the sameish just for consistency's sake.
-	// DARKPACK EDIT ADD START - Storyteller Stats
-	if(firer && ishuman(firer))
-		var/mob/living/carbon/human/human_firer = firer
-		if(prob(human_firer.st_get_stat(STAT_FIREARMS) * 10))
-			damage *= 1.4 //just a constant var in the old code, felt no need to declare it
-	// DARKPACK EDIT ADD END - Storyteller Stats
 	if (direct_target && (get_dist(direct_target, get_turf(src)) <= 1)) // point blank shots
 		impact(direct_target)
 		if (QDELETED(src))

--- a/modular_darkpack/modules/storyteller_dice/code/roll_subtypes.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_subtypes.dm
@@ -78,7 +78,6 @@
 	applicable_stats = list(STAT_DEXTERITY, STAT_FIREARMS)
 	reroll_cooldown = 1 TURNS
 	numerical = TRUE
-	difficulty = 6
 
 // Physical Feats
 /datum/storyteller_roll/lockpick

--- a/modular_darkpack/modules/storyteller_dice/code/roll_subtypes.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_subtypes.dm
@@ -78,6 +78,7 @@
 	applicable_stats = list(STAT_DEXTERITY, STAT_FIREARMS)
 	reroll_cooldown = 1 TURNS
 	numerical = TRUE
+	difficulty = 6
 
 // Physical Feats
 /datum/storyteller_roll/lockpick

--- a/modular_darkpack/modules/weapons/code/guns.dm
+++ b/modular_darkpack/modules/weapons/code/guns.dm
@@ -39,7 +39,7 @@
 	fire_sound = 'modular_darkpack/modules/weapons/sounds/revolver.ogg'
 	vary_fire_sound = FALSE
 	fire_sound_volume = 85
-	recoil = 4
+	recoil = 3
 
 /obj/item/gun/ballistic/revolver/darkpack/magnum
 	name = "magnum revolver"
@@ -55,6 +55,7 @@
 	initial_caliber = CALIBER_9MM
 	fire_sound_volume = 65
 	projectile_damage_multiplier = 1.2 //21.6 damage, slightly higher than the m1911, just so it is possible to kill NPCs within 6 bullets
+	recoil = 2
 	serial_type = "SN"
 
 /obj/item/ammo_box/magazine/internal/cylinder/rev9mm
@@ -91,7 +92,7 @@
 	inhand_icon_state = "deagle"
 	w_class = WEIGHT_CLASS_NORMAL
 	accepted_magazine_type = /obj/item/ammo_box/magazine/m44
-	recoil = 3
+	recoil = 4
 	fire_sound = 'modular_darkpack/modules/weapons/sounds/deagle.ogg'
 	serial_type = "MR"
 
@@ -112,6 +113,7 @@
 	inhand_icon_state = "deagle"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/m50
 	fire_sound_volume = 125 //MY EARS
+	recoil = 5
 	weapon_weight = WEAPON_MEDIUM	//Firing .50 at 70 dam, think this is fair.
 
 /obj/item/ammo_box/magazine/darkpack45acp
@@ -182,6 +184,7 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/glock45acp
 	burst_size = 3
 	fire_delay = 1
+	recoil = 4
 	actions_types = list()
 	bolt_type = BOLT_TYPE_LOCKING
 	fire_sound = 'modular_darkpack/modules/weapons/sounds/glock.ogg'
@@ -342,7 +345,7 @@
 	icon = 'modular_darkpack/modules/deprecated/icons/64x32.dmi'
 	ONFLOOR_ICON_HELPER('modular_darkpack/modules/weapons/icons/weapons_onfloor.dmi')
 	icon_state = "mac10_super"
-	recoil = 4
+	recoil = 5
 	spread = 8 //magic stock
 	suppressed = SUPPRESSED_QUIET
 	fire_sound = 'modular_darkpack/modules/weapons/sounds/mac10suppress.ogg'  //mac-10 recording
@@ -481,7 +484,7 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/darkpack545
 	recoil = 5
 	burst_size = 1
-	spread = 8
+	spread = 5
 	bolt_type = BOLT_TYPE_LOCKING
 	show_bolt_icon = FALSE
 	mag_display = TRUE
@@ -592,7 +595,7 @@
 	rack_sound = 'modular_darkpack/modules/weapons/sounds/bolt/lever_out.ogg'
 	bolt_drop_sound = 'modular_darkpack/modules/weapons/sounds/bolt/lever_in.ogg'
 	tac_reloads = FALSE
-	recoil = 2
+	recoil = 3
 	fire_delay = 1					//It's bolt-action. Fast as you can go really; which is still pretty slow.
 	burst_size = 1
 	slot_flags = ITEM_SLOT_BACK
@@ -630,7 +633,7 @@
 	bolt_drop_sound = 'sound/items/weapons/gun/rifle/bolt_in.ogg'
 	tac_reloads = FALSE
 	fire_delay = 40
-	recoil = 7
+	recoil = 10
 	burst_size = 1
 	//zoomable = TRUE
 	//zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.
@@ -711,7 +714,6 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/vampshotgun
 	can_be_sawn_off	= FALSE
 	fire_sound = 'modular_darkpack/modules/deprecated/sounds/pomp.ogg'
-	recoil = 4
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
 	custom_price = 1000
@@ -744,7 +746,8 @@
 	burst_fire_selection = TRUE
 	burst_size = 2	//So you can fire both barrels at once.
 	burst_delay = 2
-	recoil = 4
+	recoil = 5
+	spread = 2
 	fire_delay = 3
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/darkpack_dbarrel
 	can_be_sawn_off	= TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically does the following:
- Firearms stat **no longer** has a probability chance of doing 40% extra damage  (used to be firearm skill x 10 as prob to do 40% bonus damage)
- Firearm roll that existed already for recoil has gotten a face-lift. It now includes a reduction to spread based on the roll you did. The difficulty of the roll is now set to 6, adding +1 difficulty for akimbo or burst firearms and +2 for automatic weapons.
- Firearms have had mild tweaks to recoil and spread to accommodate for this. 

Seen here firing a bolt-action, a burst, and a full-auto
<img width="645" height="463" alt="image" src="https://github.com/user-attachments/assets/b1261964-8ab2-47e2-bd50-f9d4a2d97821" />

## Why It's Good For The Game

Overall this brings it a bit more in line with tabletop. 

It was noticed on TFN that if you rolled that 40% bonus 'crit' it could make calibers bypass armor due to raw damage output. This wasn't a huge thing but it was asked 'why is this the case' - and realized in TT firearms skill works differently.

I didn't replicate the accuracy factor on TT since automatics do not work how they do on tabletop but attempted to simulate the method in which you roll for spread and recoil instead.

This should make guns require dots to properly use them well rather than just random bonuses to damage. Felt like using full autos were strong but kicked bad, encouraging me to use burst fire guns or semis the moment I had lower skills. Even failing a 9mm roll doesn't feel that bad due to low spread low recoil but failing a roll on an AK, and Aug, or a shotgun becomes very notable. 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds recoil calc stat check to reduce spread as well
add: Adds difficulty to recoil calc
del: Removes bonus damage random chance for firearm damage based on skill probability check
balance: Redoes some weapons recoil and spread slightly; overall changes ranged from 1-2 recoil/spread so very minor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
