### PR TITLE
Silver Bullet Damage Change

### DIFF
--- a/modular_darkpack/modules/weapons/code/melee.dm
+++ b/modular_darkpack/modules/weapons/code/melee.dm
@@ -167,7 +167,7 @@
 
 /obj/item/claymore/longsword/keeper/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()
-	fera_silver_damage(target, 5, 1)
+	fera_silver_damage(target)
 
 /obj/item/melee/baseball_bat/vamp
 	name = "baseball bat"

--- a/modular_darkpack/modules/weapons/code/projectiles.dm
+++ b/modular_darkpack/modules/weapons/code/projectiles.dm
@@ -17,7 +17,7 @@
 
 /obj/projectile/bullet/darkpack/vamp9mm/silver/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-	fera_silver_damage(target, 2)
+	fera_silver_damage(target)
 
 // .45 ACP
 /obj/projectile/bullet/darkpack/vamp45acp
@@ -37,7 +37,7 @@
 
 /obj/projectile/bullet/darkpack/vamp45acp/silver/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-	fera_silver_damage(target, 3)
+	fera_silver_damage(target)
 
 // .44 Magnum
 /obj/projectile/bullet/darkpack/vamp44
@@ -53,7 +53,7 @@
 
 /obj/projectile/bullet/darkpack/vamp44/silver/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-	fera_silver_damage(target, 4)
+	fera_silver_damage(target)
 
 // .50 BMG/AE
 /obj/projectile/bullet/darkpack/vamp50

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/silver_damage.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/silver_damage.dm
@@ -16,7 +16,7 @@
 		splat.adjust_gnosis(-1, TRUE)
 
 
-/obj/projectile/bullet/proc/fera_silver_damage(mob/living/carbon/human/target, dice = 0)
+/obj/projectile/bullet/proc/fera_silver_damage(mob/living/carbon/human/target)
 	if(!istype(target))
 		return
 	var/datum/splat/werewolf/shifter/shot_pup_splat = get_shifter_splat(target)
@@ -25,10 +25,9 @@
 		shot_pup.apply_status_effect(STATUS_EFFECT_SILVER_BULLET_STACKS)
 
 		if(!shot_pup_splat.is_breed_form())
-			// IDK. This is might TTRPG inaccurate RN because i think it should acctaully convert ALL the damage to agg not just add some agg to it.
-			shot_pup.apply_damage(dice TTRPG_DAMAGE, AGGRAVATED)
+			damage_type = AGGRAVATED
 
-/obj/item/proc/fera_silver_damage(mob/living/carbon/human/target, dice = 0, gnosis_damage = 0)
+/obj/item/proc/fera_silver_damage(mob/living/carbon/human/target, gnosis_damage = 0)
 	if(!istype(target))
 		return
 	var/datum/splat/werewolf/shifter/shot_pup_splat = get_shifter_splat(target)
@@ -38,4 +37,5 @@
 
 		// W20 p. 290 - Werewolves dont take silver damage in breed form because they arent spirits
 		if(!shot_pup_splat.is_breed_form())
-			shot_pup.apply_damage(dice TTRPG_DAMAGE, AGGRAVATED)
+			// w20 core 256 - all damage becomes agg in non-breed form to garou and cannot be soaked
+			damage_type = AGGRAVATED

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/silver_damage.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/silver_damage.dm
@@ -38,4 +38,4 @@
 		// W20 p. 290 - Werewolves dont take silver damage in breed form because they arent spirits
 		if(!shot_pup_splat.is_breed_form())
 			// w20 core 256 - all damage becomes agg in non-breed form to garou and cannot be soaked
-			damage_type = AGGRAVATED
+			damtype = AGGRAVATED

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/silver_damage.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/silver_damage.dm
@@ -32,7 +32,6 @@
 		return
 	var/datum/splat/werewolf/shifter/shot_pup_splat = get_shifter_splat(target)
 	if(shot_pup_splat)
-		var/mob/living/carbon/human/shot_pup = target
 		shot_pup_splat.adjust_gnosis(-gnosis_damage, TRUE)
 
 		// W20 p. 290 - Werewolves dont take silver damage in breed form because they arent spirits


### PR DESCRIPTION
## About The Pull Request

Got requested over on TFN to make silver damage accurate to how it is in TTRPG for Garou. Basically just stops making Fera damage apply damage then a dice-damage of aggrivated damage on top of it. Instead it now just converts the damage done straight into aggravated damage.

<img width="529" height="503" alt="image" src="https://github.com/user-attachments/assets/838d1b69-97a4-41be-bbe9-bfc99081a6fa" />


Evidence of it working:
<img width="1313" height="715" alt="image" src="https://github.com/user-attachments/assets/ce994913-1f0d-49ed-bb5b-a4e069d2d15e" />

## Why It's Good For The Game

TTRPG accuracy, and stops bullets like a .44 silver from doing 35 damage + another 40 agg on top of it to a WW.

## Changelog
:cl:
balance: Removes bonus damage silver gave to Garou and instead converts all damage dealt by the silver bullet into aggrivated damage vs garou instead.
/:cl:
