### PR TITLE
Enables Minimal Renown

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -25,8 +25,12 @@
 #define JOB_UNAVAILABLE_KINDRED_GENERATION 13
 /// Checks for character clan.
 #define JOB_UNAVAILABLE_KINDRED_CLAN 14
+/// Checks for character tribe.
 #define JOB_UNAVAILABLE_FERA_TRIBE 15
+/// Checks for character auspice.
 #define JOB_UNAVAILABLE_FERA_AUSPICE 16
+/// Checks for character renown.
+#define JOB_UNAVAILABLE_FERA_RENOWN 17
 
 // DARKPACK EDIT ADD END
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -151,6 +151,8 @@
 			return "Your character's tribe is incompatible for [jobtitle]."
 		if(JOB_UNAVAILABLE_FERA_AUSPICE)
 			return "Your character's auspice is incompatible for [jobtitle]."
+		if(JOB_UNAVAILABLE_FERA_RENOWN)
+			return "Your character's renown is incompatible for [jobtitle]."
 		// DARKPACK EDIT END
 
 	return GENERIC_JOB_UNAVAILABLE_ERROR

--- a/modular_darkpack/modules/jobs/code/_job_assignment.dm
+++ b/modular_darkpack/modules/jobs/code/_job_assignment.dm
@@ -72,6 +72,10 @@
 		return JOB_UNAVAILABLE_KINDRED_CLAN
 
 /datum/controller/subsystem/job/proc/check_garou_prefs(client/player_client, mob/dead/new_player/player, datum/job/possible_job, debug_prefix = "", add_job_to_log = FALSE)
+	if((player_client.prefs.read_preference(/datum/preference/numeric/renown) > possible_job.minimal_renown_rank))
+		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_FERA_RENOWN, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
+		return JOB_UNAVAILABLE_FERA_RENOWN
+
 	var/datum/subsplat/werewolf/auspice/auspice = get_fera_auspice(player_client.prefs.read_preference(/datum/preference/choiced/subsplat/garou_auspice))
 	if(possible_job.allowed_auspice && !(auspice.name in possible_job.allowed_auspice))
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_FERA_AUSPICE, possible_job.title)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")

--- a/modular_darkpack/modules/jobs/code/pentex/affairs.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/affairs.dm
@@ -18,7 +18,7 @@
 
 	allowed_splats = list(SPLAT_GAROU)
 	minimal_masquerade = 5
-	// minimal_renown_rank = 3
+	minimal_renown_rank = 3
 	allowed_tribes = list(TRIBE_BLACK_SPIRAL_DANCERS, TRIBE_RONIN)
 
 	display_order = JOB_DISPLAY_ORDER_AFFAIRS

--- a/modular_darkpack/modules/jobs/code/pentex/branch_lead.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/branch_lead.dm
@@ -24,7 +24,7 @@
 	)
 
 	minimal_masquerade = 5
-	// minimal_renown_rank = 4
+	minimal_renown_rank = 4
 	allowed_tribes = list(TRIBE_BLACK_SPIRAL_DANCERS, TRIBE_RONIN)
 
 	display_order = JOB_DISPLAY_ORDER_BRANCH_LEAD

--- a/modular_darkpack/modules/jobs/code/pentex/executive.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/executive.dm
@@ -30,7 +30,7 @@
 
 	allowed_splats = list(SPLAT_GAROU, SPLAT_KINDRED)
 	minimal_masquerade = 4
-	// minimal_renown_rank = 3
+	minimal_renown_rank = 3
 	allowed_tribes = list(TRIBE_BLACK_SPIRAL_DANCERS, TRIBE_RONIN)
 
 	display_order = JOB_DISPLAY_ORDER_EXECUTIVE

--- a/modular_darkpack/modules/jobs/code/pentex/secchief.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/secchief.dm
@@ -18,7 +18,7 @@
 
 	allowed_splats = list(SPLAT_GAROU, SPLAT_KINDRED)
 	minimal_masquerade = 4
-	// minimal_renown_rank = 3
+	minimal_renown_rank = 3
 	allowed_tribes = list(TRIBE_BLACK_SPIRAL_DANCERS, TRIBE_RONIN)
 
 	display_order = JOB_DISPLAY_ORDER_SECCHIEF


### PR DESCRIPTION

## About The Pull Request

Just does the checks necessary for a minimum renown level for jobs. 

## Why It's Good For The Game

Was asked for to set limits on jobs given Garou are enabled for playing on TFN, seemed like a decent change for all servers using this code.

## Changelog
:cl:
add: Adds code needed for minimal renown to work and enables for jobs.
/:cl:
