### PR TITLE
(Draft) Potence Active Alternative - BP Consumed on Hit/Action

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
@@ -1,3 +1,5 @@
+#define COMBAT_COOLDOWN_LENGTH 15 SECONDS
+
 /datum/discipline/potence
 	name = "Potence"
 	desc = "Boosts melee and unarmed damage."
@@ -15,7 +17,15 @@
 	check_flags = DISC_CHECK_CAPABLE
 
 	toggled = TRUE
-	duration_length = 1 TURNS
+	vitae_cost = 0
+	duration_length = 0
+
+	var/static/list/attack_signals = list(
+		COMSIG_MOB_ATTACK_HAND,
+		COMSIG_ATOM_ATTACKBY,
+		COMSIG_MOB_ITEM_ATTACK,
+		COMSIG_LIVING_GRAB
+	)
 
 /datum/discipline_power/potence/post_gain()
 	owner.st_add_stat_mod(STAT_STRENGTH, level, "Potence")
@@ -23,8 +33,15 @@
 /datum/discipline_power/potence/post_loss()
 	owner.st_remove_stat_mod(STAT_STRENGTH, "Potence")
 
+/datum/discipline_power/potence/pre_activation_checks()
+	. = ..()
+	if(owner.bloodpool <= 0)
+		to_chat(owner, span_danger("You do not have enough BP to use Potence!"))
+
 /datum/discipline_power/potence/activate()
 	. = ..()
+
+	RegisterSignals(owner, attack_signals, PROC_REF(on_attack_signal))
 
 	if(level <= 5)
 		var/max_level = min(discipline.level, 5)
@@ -32,9 +49,24 @@
 
 /datum/discipline_power/potence/deactivate()
 	. = ..()
+
+	UnregisterSignal(owner, attack_signals)
+
 	if(level <= 5)
 		owner.remove_status_effect(/datum/status_effect/potence)
 
+/datum/discipline_power/potence/proc/on_attack_signal(datum/source)
+	SIGNAL_HANDLER
+
+	if(owner.bloodpool <= 0)
+		to_chat(owner, span_warning("You don't have enough blood to keep [src] active!"))
+		try_deactivate(direct = TRUE)
+
+		deltimer(cooldown_timer)
+		cooldown_timer = addtimer(CALLBACK(src, PROC_REF(cooldown_expire)), COMBAT_COOLDOWN_LENGTH, TIMER_STOPPABLE | TIMER_DELETE_ME)
+
+	to_chat(owner, span_warning("[src] consumes your blood to stay active."))
+	owner.adjust_blood_pool(-1)
 
 //POTENCE 1
 /datum/discipline_power/potence/one
@@ -109,3 +141,5 @@
 		/datum/discipline_power/potence/three,
 		/datum/discipline_power/potence/four
 	)
+
+#undef COMBAT_COOLDOWN_LENGTH


### PR DESCRIPTION

## About The Pull Request

This is a draft currently purely for feedback. Members of TFN's community gave feedback that potence's drain at 1 turn length made it a massive BP drain for minimal returns compared to Celerity, or the fact you were draining usually 2 BP before you'd even get a roll off to bash down a door.

This was a solution floated in OOC chat and had some support seemingly in discussions. Potence consuming BP per-action rather than turn. This way punching a door will take 1 BP for the door, not a timer - or you can use potence in an active fight and only lose BP when you are attacking verses when you are unable to even swing a the mob.

**This is drafted for more open feedback**, happy to hear input or alternative ideas - or if people think it's better as is rather than this.

Also - door hitting isn't fully accounted for. It.. seems to work? But it need to def be cleaner, it's not working every time I noticed. Issue on my end with the signals I'm sure.

## Why It's Good For The Game

See above; basically listed it there. 

Tl;dr - makes potence drain your BP only when you take actions rather than at rapid rates when you typically don't even get to hit something per-turn or when actions take longer than a normal turns length.

## Changelog
:cl:
balance: Removes Potence's toggle cost but instead makes it drain 1 BP per action.
/:cl:
