### PR TITLE
Area name fixes

### DIFF
--- a/modular_darkpack/master_files/code/controllers/subsystem/ambience.dm
+++ b/modular_darkpack/master_files/code/controllers/subsystem/ambience.dm
@@ -1,13 +1,19 @@
+// AREAS
 /mob/living/update_ambience_area(area/new_area)
 	. = ..()
 	if(!client)
 		return
+	if(!new_area.show_area_name)
+		return
+	if(last_shown_area_name == new_area.name)
+		return
+	last_shown_area_name = new_area.name
 	for(var/atom/movable/screen/area_text/old in client.screen)
 		qdel(old)
 	var/atom/movable/screen/area_text/T = new()
 	client.screen += T
 	T.maptext = MAPTEXT({"<span style='font-size: 200%; text-shadow: 1px 1px 2px black, 0 0 1em black, 0 0 0.2em black; display: block; text-align: center;'>[new_area.name]</span>"})
-	animate(T, alpha = 255, time = 10, easing = EASE_IN)
+	animate(T, alpha = 255, time = 1 SECONDS, easing = EASE_IN)
 	addtimer(CALLBACK(src, PROC_REF(clear_area_text), T), 4 SECONDS)
 
 // this shouldnt be here since its not an override or a subtype of a /tg/ proc (like above) but since it's called right there i figured i'd keep things together.

--- a/modular_darkpack/master_files/code/game/area/areas.dm
+++ b/modular_darkpack/master_files/code/game/area/areas.dm
@@ -14,6 +14,8 @@
 	var/max_music_cooldown = 2 MINUTES
 	// END - AMBIENCE
 
+	var/show_area_name = TRUE // AREAS
+
 /area/Initialize(mapload)
 	// START - AMBIENCE
 	if(!musictracks)

--- a/modular_darkpack/master_files/code/modules/mob/living/living_defines.dm
+++ b/modular_darkpack/master_files/code/modules/mob/living/living_defines.dm
@@ -53,3 +53,5 @@
 	//thaumaturgy & necro path stuff
 	var/research_points = 0
 	var/collected_souls = 0
+
+	var/last_shown_area_name // AREAS

--- a/modular_darkpack/modules/areas/code/random_gen.dm
+++ b/modular_darkpack/modules/areas/code/random_gen.dm
@@ -1,14 +1,15 @@
 /area/vtm/planetgeneration
-	name = "forest generation area"
+	name = "Forest"
 	icon_state = "park"
-	outdoors = TRUE
 	map_generator = /datum/map_generator/jungle_generator
+	zone_type = ZONE_NO_MASQUERADE
+	sound_environment = SOUND_ENVIRONMENT_FOREST
 	gauntlet_rating = 6
-
+	requires_power = FALSE
+	domain = TRUE
+	outdoors = TRUE
 
 /area/vtm/planetgeneration/woodland
-	name = "woodland generation area"
+	name = "Woodland"
 	icon_state = "cog_caern"
-	outdoors = TRUE
 	map_generator = /datum/map_generator/jungle_generator/woodland
-	gauntlet_rating = 6


### PR DESCRIPTION

## About The Pull Request
Areas wont show the same name twice (so reentering and area or one with the same name) to not spam
fixes the mapgen areas to have real names and cleans up some varibles.
adds a flag to just not show the name in a popup incase its a weird area/name
## Why It's Good For The Game
fix
## Changelog
:cl:
fix: The same area name wont be shown twice when entering areas
fix: Generate forest has a correct area name
/:cl:
