### PR TITLE
Cleans up frenzy verb display

### DIFF
--- a/modular_darkpack/modules/frenzy/code/frenzy.dm
+++ b/modular_darkpack/modules/frenzy/code/frenzy.dm
@@ -119,10 +119,9 @@
 	return frenzy_result
 
 
-/mob/living/carbon/human/verb/manual_frenzy_roll(atom/movable/AM as mob|obj in oview(DEFAULT_SIGHT_DISTANCE))
+/mob/living/carbon/human/proc/manual_frenzy_roll(atom/movable/AM as mob|obj in oview(DEFAULT_SIGHT_DISTANCE))
 	set name = "Manual Frenzy Roll"
 	set desc = "Trigger a roll for a frenzy"
-	set category = "Object"
 
 	if(!istype(AM))
 		return
@@ -138,7 +137,6 @@
 /mob/living/carbon/human/proc/manual_frenzy(atom/movable/AM as mob|obj in oview(DEFAULT_SIGHT_DISTANCE))
 	set name = "Manual Frenzy"
 	set desc = "Enter a frenzy at will"
-	set category = "Object"
 
 	if(!istype(AM))
 		return

--- a/modular_darkpack/modules/splats/code/__splat.dm
+++ b/modular_darkpack/modules/splats/code/__splat.dm
@@ -36,6 +36,9 @@
 	/// Base type of the powers that this splat has
 	var/power_type
 
+	/// Can frenzy and is given a verb to manually do it.
+	var/can_frenzy = TRUE
+
 	/// Splats that someone with this splat cannot gain
 	var/list/incompatible_splats
 

--- a/modular_darkpack/modules/splats/code/gaining_splats.dm
+++ b/modular_darkpack/modules/splats/code/gaining_splats.dm
@@ -37,6 +37,9 @@
 	add_actions()
 	add_biotypes()
 
+	if(can_frenzy)
+		add_verb(owner, /mob/living/carbon/human/proc/manual_frenzy_roll)
+
 	on_gain()
 
 	if(owner.hud_used)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. hides it from the verb panel. Its the type of verb you would never call from there and are more likely to right click your target. additionaly it was in a tab by itself (I belive due to TG's (smartkar's) goal of removing the panel meaning its a little volatite rn from tg pulls.
2. Only even grant it if your a supernatural. We have a return for if you arent one anyway.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Frenzy verb is no longer displayed in the verb panel. It can still be found in the context menu for mobs.
qol: Frenzy verb only displays if your a supernatural
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
