### PR TITLE
Attack roll balloon alerts made more clear

### DIFF
--- a/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
@@ -11,6 +11,9 @@
 	var/roll_output_type = ROLL_PUBLIC
 	/// This is a roll that can proc multiple times in rapid sucession and thus has weaker or less notible outputs (forced runechat and quieter dice rolls)
 	var/spammy_roll = FALSE
+	/// If set, a character or unicode appended to the front of balloon alerts to help convey what the roll is for.
+	var/alert_prefix
+	var/alert_delay
 
 	/// A lazy list of times indexed by a weakref to a mob
 	var/list/mobs_last_rolled
@@ -81,16 +84,27 @@
 			to_chat(player_mob, output_combined, MESSAGE_TYPE_INFO, trailing_newline = FALSE)
 			SEND_SOUND(player_mob, sound('sound/items/dice_roll.ogg', volume = roll_important_to_me ? 5 : 20))
 		else
-			if(last_sucess_amount > 0)
-				roller.balloon_alert(player_mob, "<span style='color: #14a833;'>[last_sucess_amount]</span>", TRUE)
+			if(alert_delay)
+				var/using_number = last_sucess_amount
+				spawn(alert_delay)
+					create_balloon_alert(roller, player_mob, using_number)
 			else
-				roller.balloon_alert(player_mob, "<span style='color: #ff0000;'>[last_sucess_amount]</span>", TRUE)
+				create_balloon_alert(roller, player_mob, last_sucess_amount)
+
 
 	LAZYADDASSOC(mobs_last_rolled, WEAKREF(roller), list(world.time, output))
 
 	SEND_SIGNAL(roller, COMSIG_LIVING_DICE_ROLLED, src, output)
 	return output
 
+/datum/storyteller_roll/proc/create_balloon_alert(mob/living/roller, mob/player_mob, number)
+	if(QDELETED(roller) || QDELETED(player_mob))
+		return
+
+	if(number > 0)
+		roller.balloon_alert(player_mob, "<span style='color: #14a833;'>[alert_prefix][number]</span>", TRUE)
+	else
+		roller.balloon_alert(player_mob, "<span style='color: #ff0000;'>[alert_prefix][number]</span>", TRUE)
 
 /datum/storyteller_roll/proc/get_mobs_to_show(mob/living/roller, atom/target)
 	switch(roll_output_type)

--- a/modular_darkpack/modules/storyteller_dice/code/roll_subtypes.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_subtypes.dm
@@ -14,6 +14,7 @@
 /datum/storyteller_roll/attack
 	bumper_text = "attack"
 	spammy_roll = TRUE
+	alert_prefix = "⚔"
 	applicable_stats = list(STAT_DEXTERITY, STAT_BRAWL)
 
 /datum/storyteller_roll/attack/punch
@@ -39,6 +40,9 @@
 	bumper_text = "damage"
 	numerical = TRUE
 	spammy_roll = TRUE
+	// Ok listen I know this is just an emoji but it looks fine ingame.
+	alert_prefix = "✊"
+	alert_delay = 0.2 SECONDS
 	applicable_stats = list(STAT_STRENGTH)
 
 /datum/storyteller_roll/damage/punch


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds support for a prefix to the alert plus a buffer to the alert. This only works because we know there will always be a roll on the same frame as the damage meaning we can blindly buffer it for a moment. It feels extremely hacky.

We really ought to have a system that buffers them more sanely but that would have knock on effects for other balloon alerts which worries me.

I might have a flag for putting SPECIFIC rolls into a queue. (so attack and damage) so that only they are affected by the queue? This works for now.

https://github.com/user-attachments/assets/0d2c2cb5-94cf-4381-afce-0537114019f9

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Old balloon alerts were useless as the stacked messages made it impossible to parse what the results were.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Combat dice-rolls are displayed more clearly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
