### PR TITLE
Update obtenebration.dm

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -239,6 +239,8 @@
 	cooldown_length = 1 TURNS
 	var/activating = FALSE
 	var/saved_brute_mod = 1
+	var/saved_burn_mod = 1
+	var/saved_aggravated_mod = 1
 	var/saved_clone_mod = 1
 	var/saved_stamina_mod = 1
 	var/saved_brain_mod = 1
@@ -273,8 +275,10 @@
 	playsound(owner.loc, 'sound/effects/magic/voidblink.ogg', 50, FALSE)
 	saved_brute_mod = owner.physiology.brute_mod
 	owner.physiology.brute_mod = 0
-	//saved_clone_mod = owner.physiology.clone_mod
-	//owner.physiology.clone_mod = 0
+	saved_burn_mod = owner.physiology.burn_mod
+	owner.physiology.burn_mod = 2
+	saved_aggravated_mod= owner.physiology.aggravated_mod
+	owner.physiology.aggravated_mod = 0
 	saved_stamina_mod = owner.physiology.stamina_mod
 	owner.physiology.stamina_mod = 0
 	saved_brain_mod = owner.physiology.brain_mod
@@ -285,7 +289,8 @@
 	ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC_TRAIT)
 	ADD_TRAIT(owner, TRAIT_NOBLOOD, MAGIC_TRAIT)
 	ADD_TRAIT(owner, TRAIT_PACIFISM, MAGIC_TRAIT) // Can't physically attack while in this form
-	//ADD_TRAIT(owner, TRAIT_MOVE_FLYING, MAGIC_TRAIT) // Flying to simulate being unaffected by gravity
+	ADD_TRAIT(owner, TRAIT_MOVE_FLYING, MAGIC_TRAIT) // Flying to simulate being unaffected by gravity
+	ADD_TRAIT(owner, TRAIT_PIERCEIMMUNE, MAGIC_TRAIT)	//Stops bullets from embedding and taser electrodes no longer connect
 	owner.pass_flags |= (PASSDOORS | PASSTABLE | PASSSTRUCTURE) // Phase through doors & fences / tables / machines, dumpsters, barrels, lampposts
 
 
@@ -297,7 +302,8 @@
 	to_chat(owner, span_notice("You return to your normal form."))
 	playsound(owner.loc, 'sound/effects/magic/voidblink.ogg', 50, FALSE)
 	owner.physiology.brute_mod = saved_brute_mod
-	//owner.physiology.clone_mod = saved_clone_mod
+	owner.physiology.burn_mod = saved_burn_mod
+	owner.physiology.aggravated_mod = saved_aggravated_mod
 	owner.physiology.stamina_mod = saved_stamina_mod
 	owner.physiology.brain_mod = saved_brain_mod
 	animate(owner, color = initial(owner.color), time = 1 SECONDS, loop = 1)
@@ -306,7 +312,8 @@
 	REMOVE_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC_TRAIT)
 	REMOVE_TRAIT(owner, TRAIT_NOBLOOD, MAGIC_TRAIT)
 	REMOVE_TRAIT(owner, TRAIT_PACIFISM, MAGIC_TRAIT)
-	//REMOVE_TRAIT(owner, TRAIT_MOVE_FLYING, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_MOVE_FLYING, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_PIERCEIMMUNE, MAGIC_TRAIT)	//Stops bullets from embedding and taser electrodes no longer connect
 	owner.pass_flags &= ~(PASSDOORS | PASSTABLE | PASSSTRUCTURE)
 
 	owner.density = saved_density

--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -289,7 +289,7 @@
 	ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC_TRAIT)
 	ADD_TRAIT(owner, TRAIT_NOBLOOD, MAGIC_TRAIT)
 	ADD_TRAIT(owner, TRAIT_PACIFISM, MAGIC_TRAIT) // Can't physically attack while in this form
-	ADD_TRAIT(owner, TRAIT_MOVE_FLYING, MAGIC_TRAIT) // Flying to simulate being unaffected by gravity
+	//ADD_TRAIT(owner, TRAIT_MOVE_FLYING, MAGIC_TRAIT) // Flying to simulate being unaffected by gravity
 	ADD_TRAIT(owner, TRAIT_PIERCEIMMUNE, MAGIC_TRAIT)	//Stops bullets from embedding and taser electrodes no longer connect
 	owner.pass_flags |= (PASSDOORS | PASSTABLE | PASSSTRUCTURE) // Phase through doors & fences / tables / machines, dumpsters, barrels, lampposts
 
@@ -312,7 +312,7 @@
 	REMOVE_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC_TRAIT)
 	REMOVE_TRAIT(owner, TRAIT_NOBLOOD, MAGIC_TRAIT)
 	REMOVE_TRAIT(owner, TRAIT_PACIFISM, MAGIC_TRAIT)
-	REMOVE_TRAIT(owner, TRAIT_MOVE_FLYING, MAGIC_TRAIT)
+	//REMOVE_TRAIT(owner, TRAIT_MOVE_FLYING, MAGIC_TRAIT)
 	REMOVE_TRAIT(owner, TRAIT_PIERCEIMMUNE, MAGIC_TRAIT)	//Stops bullets from embedding and taser electrodes no longer connect
 	owner.pass_flags &= ~(PASSDOORS | PASSTABLE | PASSSTRUCTURE)
 


### PR DESCRIPTION

## About The Pull Request

https://github.com/The-Final-Nights/The-Final-Nights-Rebase/pull/332

Mirrors fix on downstream, fixes Obten 5 still taking embeding damage which allowed you to shoot out eyes of targets despite being damage immune. Also Gangrel claws were fully ignoring the form, only fire-based Agg damage is supposed to effect them; not physical agg.

Plus doubles the incoming burn damage as it says in TT material. Re-enables flying too since it's slower than mist form and very obvious anyway. (Think it's TT accurate, hard to tell due to vaugeness of what 'gravity immune' means.)

## Why It's Good For The Game

Fixes Obten 5 to no longer be able to take damage from bullet embedding stuff. Plus TT accurate changes to let you actually counter people properly in shadow form still.

## Changelog
:cl:
fix: Fixes Obtenebrate embedding issue
balance: Makes Obten 5 TT accurate with burns, agg damage, etc.
/:cl:
