### PR TITLE
Update protean.dm

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/protean/protean.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/protean.dm
@@ -171,7 +171,7 @@
 	if(do_after(owner, 3 TURNS, timed_action_flags = IGNORE_USER_LOC_CHANGE))
 		return TRUE
 	else
-		to_chat(owner, span_warning("You are unable rendered unable to transform!"))
+		to_chat(owner, span_warning("You are rendered unable to transform!"))
 		return FALSE
 
 /datum/discipline_power/protean/shape_of_the_beast/activate()

--- a/modular_darkpack/modules/powers/code/discipline/protean/protean.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/protean.dm
@@ -76,7 +76,7 @@
 	if(do_after(owner, 1 TURNS, timed_action_flags = IGNORE_USER_LOC_CHANGE))
 		return TRUE
 	else
-		to_chat(owner, span_warning("You are unable rendered unable to transform!"))
+		to_chat(owner, span_warning("You are rendered unable to transform!"))
 		return FALSE
 
 /datum/discipline_power/protean/feral_claws/activate()

--- a/modular_darkpack/modules/powers/code/discipline/protean/protean.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/protean.dm
@@ -219,7 +219,7 @@
 	if(do_after(owner, 3 TURNS, timed_action_flags = IGNORE_USER_LOC_CHANGE))
 		return TRUE
 	else
-		to_chat(owner, span_warning("You are unable rendered unable to transform!"))
+		to_chat(owner, span_warning("You are rendered unable to transform!"))
 		return FALSE
 
 /datum/discipline_power/protean/mist_form/activate()

--- a/modular_darkpack/modules/powers/code/discipline/protean/protean.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/protean.dm
@@ -71,6 +71,14 @@
 
 	grouped_powers = list()
 
+/datum/discipline_power/protean/feral_claws/pre_activation_checks(atom/target)
+	. = ..()
+	if(do_after(owner, 1 TURNS, timed_action_flags = IGNORE_USER_LOC_CHANGE))
+		return TRUE
+	else
+		to_chat(owner, span_warning("You are unable rendered unable to transform!"))
+		return FALSE
+
 /datum/discipline_power/protean/feral_claws/activate()
 	. = ..()
 	owner.drop_all_held_items()
@@ -158,6 +166,14 @@
 
 	var/datum/action/cooldown/spell/shapeshift/gangrel/beast_form/gangy_form
 
+/datum/discipline_power/protean/shape_of_the_beast/pre_activation_checks(atom/target)
+	. = ..()
+	if(do_after(owner, 3 TURNS, timed_action_flags = IGNORE_USER_LOC_CHANGE))
+		return TRUE
+	else
+		to_chat(owner, span_warning("You are unable rendered unable to transform!"))
+		return FALSE
+
 /datum/discipline_power/protean/shape_of_the_beast/activate()
 	. = ..()
 	if(gangy_form)
@@ -197,6 +213,14 @@
 	)
 
 	var/datum/action/cooldown/spell/shapeshift/gangrel/mist/mist_form
+
+/datum/discipline_power/protean/mist_form/pre_activation_checks(atom/target)
+	. = ..()
+	if(do_after(owner, 3 TURNS, timed_action_flags = IGNORE_USER_LOC_CHANGE))
+		return TRUE
+	else
+		to_chat(owner, span_warning("You are unable rendered unable to transform!"))
+		return FALSE
 
 /datum/discipline_power/protean/mist_form/activate()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

https://github.com/The-Final-Nights/The-Final-Nights-Rebase/pull/331

Mirrors from drownstream, Protean is pretty strong and misting is instant so making it akin to TT with a delay for claws, beast form, and misting with how TT does it fixes some of the issues had.

## Why It's Good For The Game

Mirrors how it works on TT basically, fixes some balance issues with misting being instant transform and all.

## Changelog
:cl:
balance: Protean 2, 4, and 5 have proper delays added in accordance with TT discipline use.
/:cl:
