### PR TITLE
odious chalice and other artifact fixes

### DIFF
--- a/modular_darkpack/modules/occult_artifacts/code/_artifact.dm
+++ b/modular_darkpack/modules/occult_artifacts/code/_artifact.dm
@@ -57,6 +57,8 @@
 	grant_powers()
 
 /obj/item/occult_artifact/proc/unbind(mob/user)
+	if(src in owner?.get_all_contents()) // dont unbind if the user has just placed the artifact in their bag - which counts as dropping it
+		return
 	var/datum/controller/subsystem/processing/subsystem = locate(subsystem_type) in Master.subsystems
 	STOP_PROCESSING(subsystem, src)
 

--- a/modular_darkpack/modules/occult_artifacts/code/artifacts/heart_of_eliza.dm
+++ b/modular_darkpack/modules/occult_artifacts/code/artifacts/heart_of_eliza.dm
@@ -10,4 +10,4 @@
 
 /obj/item/occult_artifact/vampire/heart_of_eliza/ungrant_powers()
 	. = ..()
-	owner.st_remove_stat_mod(STAT_STRENGTH, 1, type)
+	owner.st_remove_stat_mod(STAT_STRENGTH, type)

--- a/modular_darkpack/modules/occult_artifacts/code/artifacts/odious_chalice.dm
+++ b/modular_darkpack/modules/occult_artifacts/code/artifacts/odious_chalice.dm
@@ -4,10 +4,37 @@
 	icon_state = "o_chalice"
 	var/stored_blood = 0
 	research_value = 30
+	COOLDOWN_DECLARE(chalice_alert_cooldown)
 
 /obj/item/occult_artifact/vampire/odious_chalice/examine(mob/user)
 	. = ..()
 	. += "[src] contains [stored_blood] blood points..."
+
+/obj/item/occult_artifact/vampire/odious_chalice/grant_powers()
+	. = ..()
+	RegisterSignal(owner, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_attack))
+
+/obj/item/occult_artifact/vampire/odious_chalice/proc/on_attack(mob/living/source, mob/living/target, mob/living/user, list/modifiers, list/attack_modifiers)
+	if(!identified)
+		return
+	var/obj/item/weapon = source.get_active_held_item()
+	if(!weapon?.get_sharpness())
+		return
+	if(!prob(50))
+		return
+	if(!(src in source.get_all_contents()))
+		return
+	if(!target.bloodpool && !target.blood_volume)
+		return
+	stored_blood++
+	if(COOLDOWN_FINISHED(src, chalice_alert_cooldown))
+		//rather spammy. 1 scene cooldown
+		balloon_alert(source, "the chalice drinks...")
+		COOLDOWN_START(src, chalice_alert_cooldown, 1 SCENES)
+
+/obj/item/occult_artifact/vampire/odious_chalice/ungrant_powers()
+	. = ..()
+	UnregisterSignal(owner, COMSIG_MOB_ITEM_ATTACK)
 
 /obj/item/occult_artifact/vampire/odious_chalice/attack(mob/living/M, mob/living/user)
 	. = ..()

--- a/modular_darkpack/modules/occult_artifacts/code/artifacts/odious_chalice.dm
+++ b/modular_darkpack/modules/occult_artifacts/code/artifacts/odious_chalice.dm
@@ -13,7 +13,7 @@
 	. = ..()
 	if(!get_kindred_splat(M))
 		return
-	if(!stored_blood)
+	if(stored_blood <= 0)
 		return
 	if(!identified)
 		return
@@ -21,5 +21,6 @@
 	M.adjust_fire_loss(-5*stored_blood, TRUE)
 	M.update_damage_overlays()
 	M.update_health_hud()
+	stored_blood--
 	playsound(M.loc,'sound/items/drink.ogg', 50, TRUE)
 	return

--- a/modular_darkpack/modules/occult_artifacts/code/fetishes/nyxs_bangle.dm
+++ b/modular_darkpack/modules/occult_artifacts/code/fetishes/nyxs_bangle.dm
@@ -18,9 +18,7 @@
 
 /obj/item/occult_artifact/werewolf/nyxs_bangle/ungrant_powers()
 	. = ..()
-
 	owner.alpha = 255
-
 
 /obj/item/occult_artifact/werewolf/nyxs_bangle/process(seconds_per_tick)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

artifacts currently dont work if you place them in your bag, this pr fixes that

fixes odious chalice so that it works

## Why It's Good For The Game

old flavcode snowflaked checking for identified odious chalice into item attack code lol, this approach uses signals

## Changelog
:cl:

fix: fixes artifacts from being unbinded from the user when placed into a satchel
fix: fixes the odious chalice so that it works

/:cl:


