### PR TITLE
Stumps no longer reference "the station"

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -330,7 +330,7 @@
 
 /obj/structure/flora/tree/stump
 	name = "stump"
-	desc = "This represents our promise to the crew, and the station itself, to cut down as many trees as possible." //running naked through the trees
+	desc = "The remains of a once great tree. A deeply rooted stump." // DARKPACK EDIT CHANGE - (tg lore cruft)
 	icon = 'icons/obj/fluff/flora/pinetrees.dmi'
 	icon_state = "tree_stump"
 	density = FALSE


### PR DESCRIPTION

## About The Pull Request
yeagh
## Why It's Good For The Game
cruft.
## Changelog
:cl:
spellcheck: Tree stumps dont reference ss13
/:cl:
