### PR TITLE
Fix Mage Blood removing Bloodheal bug

### DIFF
--- a/modular_darkpack/modules/merits_flaws/code/negative_quirks/mage_blood.dm
+++ b/modular_darkpack/modules/merits_flaws/code/negative_quirks/mage_blood.dm
@@ -11,6 +11,7 @@
 	if(!kindred_splat)
 		return
 	for(var/datum/action/discipline/action as anything in kindred_splat.powers)
-		if(!istype(action.discipline, /datum/discipline/thaumaturgy))
+		// Unselectable Disciplines have special handling (e.g. Bloodheal) and are excluded
+		if(!istype(action.discipline, /datum/discipline/thaumaturgy) && action.discipline.selectable)
 			kindred_splat.remove_power(action.discipline.type)
 


### PR DESCRIPTION

## About The Pull Request
Fixes #1098 by ensuring Disciplines which aren't normally selectable (like Bloodheal) don't get removed by Mage Blood.
## Why It's Good For The Game
Mage Blood (as per Lore of the Clans p. 219) is only meant to apply to Disciplines. The ability to heal using vitae isn't a Discipline in lore, but in code we treat it as a Discipline which is where this oversight came from.

<img width="583" height="216" alt="image" src="https://github.com/user-attachments/assets/3b07403d-726d-4cea-9ce3-2503c982d2e1" />

## Changelog
:cl:
fix: The Mage Blood disadvantage no longer removes Bloodheal
/:cl:
