### PR TITLE
Fix Garou transforming while resting

### DIFF
--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/transformation.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/transformation.dm
@@ -17,7 +17,7 @@
 	if(istype(current_form, form_to_transform))
 		return
 	if(!force && !COOLDOWN_FINISHED(src, transform_cd))
-		to_chat(owner, span_warning("Your shifting is on cooldown for one turn."))
+		to_chat(owner, span_warning("Your shifting is on cooldown for [DisplayTimeText(COOLDOWN_TIMELEFT(src, transform_cd))]."))
 		return
 
 	if(HAS_TRAIT(owner, TRAIT_METAMORPH))
@@ -86,6 +86,14 @@
 
 /datum/splat/werewolf/shifter/proc/transform_finish(form_to_transform, time_taken = DOGGY_ANIMATION_TIME)
 	animate(owner, transform = null, color = "#FFFFFF", time = time_taken * 0.1)
+
+	// Hacky fix for angle getting messed up when transforming into a human while resting
+	if (owner.body_position == LYING_DOWN && ispath(form_to_transform, /datum/species/human/shifter/homid))
+		var/previous_angle = owner.set_lying_angle(0)
+		owner.set_species(form_to_transform)
+		owner.set_lying_angle(previous_angle)
+		return
+
 	owner.set_species(form_to_transform)
 
 /datum/splat/werewolf/shifter/proc/is_breed_form()

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/subsplats/breeds/garou.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/subsplats/breeds/garou.dm
@@ -15,7 +15,7 @@
 	breed_species = /datum/species/human/shifter/war
 
 /datum/subsplat/werewolf/breed_form/garou/crinos/generation_pref_icon(datum/universal_icon/main_icon)
-	var/datum/universal_icon/breed_lupus = uni_icon('modular_darkpack/modules/werewolf_the_apocalypse/icons/garou_forms/lupus.dmi', "black")
+	var/datum/universal_icon/breed_lupus = uni_icon('modular_darkpack/modules/werewolf_the_apocalypse/icons/garou_forms/crinos.dmi', "black")
 	breed_lupus.scale(32, 32)
 	main_icon.blend_icon(breed_lupus, ICON_OVERLAY)
 
@@ -26,6 +26,6 @@
 	breed_species = /datum/species/human/shifter/feral
 
 /datum/subsplat/werewolf/breed_form/garou/lupus/generation_pref_icon(datum/universal_icon/main_icon)
-	var/datum/universal_icon/breed_crinos = uni_icon('modular_darkpack/modules/werewolf_the_apocalypse/icons/garou_forms/crinos.dmi', "black")
+	var/datum/universal_icon/breed_crinos = uni_icon('modular_darkpack/modules/werewolf_the_apocalypse/icons/garou_forms/lupus.dmi', "black")
 	breed_crinos.scale(32, 32)
 	main_icon.blend_icon(breed_crinos, ICON_OVERLAY)


### PR DESCRIPTION

## About The Pull Request
Fixes #1056 and ensures angle will always be consistent when switching between forms. Also fixes the preference icons for Breed so that Lupus and Crinos have the correct icons. Also displays the exact time remaining until you can try to transform again rather than just displaying "one turn".
## Why It's Good For The Game
Fixes a few known issues as well as providing a minor QOL tweak for garou.
## Changelog
:cl:
fix: Garou no longer go upside down when transforming into Homid while resting
/:cl:
