### PR TITLE
Underplates layer above tables

### DIFF
--- a/modular_darkpack/modules/decor/code/decor.dm
+++ b/modular_darkpack/modules/decor/code/decor.dm
@@ -451,7 +451,7 @@
 	name = "underplate"
 	icon = 'modular_darkpack/modules/decor/icons/restaurant.dmi'
 	icon_state = "underplate"
-	layer = TABLE_LAYER
+	layer = LOW_ITEM_LAYER
 	anchored = TRUE
 
 /obj/underplate/stuff

--- a/modular_darkpack/modules/decor/code/decor.dm
+++ b/modular_darkpack/modules/decor/code/decor.dm
@@ -451,7 +451,6 @@
 	name = "underplate"
 	icon = 'modular_darkpack/modules/decor/icons/restaurant.dmi'
 	icon_state = "underplate"
-	layer = LOW_ITEM_LAYER
 	anchored = TRUE
 
 /obj/underplate/stuff


### PR DESCRIPTION

## About The Pull Request
The little fluff props in reasturants were laying under tables/platforms.
Fixes that.
## Why It's Good For The Game
Where my damn table fluff go (also why is this not an item...)
## Changelog
:cl:
fix: underplates layer above tables again
/:cl:
