### PR TITLE
fixes sarcophagus event firing five times

### DIFF
--- a/modular_darkpack/modules/events/code/sarcophagus_event.dm
+++ b/modular_darkpack/modules/events/code/sarcophagus_event.dm
@@ -11,6 +11,8 @@
 
 /datum/round_event_control/darkpack/sarcophagus/can_spawn_event(players_amt, allow_magic)
 	. = ..()
+	if(!.)
+		return FALSE
 	var/list/valid_landmarks = list()
 	for(var/obj/effect/landmark/event_spawn/sarcophagus/L in GLOB.generic_event_spawns)
 		var/player_nearby = FALSE

--- a/modular_darkpack/modules/events/code/sarcophagus_event.dm
+++ b/modular_darkpack/modules/events/code/sarcophagus_event.dm
@@ -30,13 +30,14 @@
 	announce_when = 5
 
 /datum/round_event/sarcophagus/announce(fake)
-	priority_announce(
-		"You receive a notification about a viral Endpost - a respected archaeologist notes that the location of a long-lost Assyrian sarcophagus alongside it's key, which was famously stolen, seems to be in your city according to newly published criminological records tracking the suspected thief.",
-		"Viral News Story",
-		'modular_darkpack/modules/events/sounds/news_notification.ogg',
-		ANNOUNCEMENT_TYPE_PRIORITY,
-		color_override = "yellow",
-	)
+	if(prob(20))
+		priority_announce(
+			"You receive a notification about a viral Endpost - a respected archaeologist notes that the location of a long-lost Assyrian sarcophagus alongside it's key, which was famously stolen, seems to be in your city according to newly published criminological records tracking the suspected thief.",
+			"Viral News Story",
+			'modular_darkpack/modules/events/sounds/news_notification.ogg',
+			ANNOUNCEMENT_TYPE_PRIORITY,
+			color_override = "yellow",
+		)
 
 /datum/round_event/sarcophagus/start()
 	var/list/landmarks = list()


### PR DESCRIPTION
## About The Pull Request

it was firing many many times because it didnt consider the parent's return lol, woops

## Why It's Good For The Game

bugfix

## Changelog

:cl:
add: sarcophagus event's announcement now only fires 20% of the time for added stealth
fix: sarcophagus event will now fire only once per round max
/:cl:


