### PR TITLE
Corax fur color wont override Garou's

### DIFF
--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/preferences/fur.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/preferences/fur.dm
@@ -7,6 +7,7 @@
 	main_feature_name = "Fera Fur Color"
 	relevant_inherent_trait = TRAIT_FERA_FUR
 	must_have_relevant_trait = TRUE
+	must_be_accessible = TRUE
 	var/splat_id
 
 /datum/preference/choiced/fera_fur_color/apply_to_human(mob/living/carbon/human/target, value)


### PR DESCRIPTION

## About The Pull Request
fixes #1119 
## Why It's Good For The Game
## Changelog
:cl:
fix: Corax and Garou fur colors wont override one another
/:cl:
