### PR TITLE
Zulo form is properly restricted to spalts with clans

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/vicissitude/zulo.dm
+++ b/modular_darkpack/modules/powers/code/discipline/vicissitude/zulo.dm
@@ -48,10 +48,10 @@ GLOBAL_LIST_INIT(zulo_forms, list(
 
 /mob/living/basic/zulo/Initialize(mapload)
 	. = ..()
-	ADD_TRAIT(src, TRAIT_UNMASQUERADE, type)
+	ADD_TRAIT(src, TRAIT_UNMASQUERADE, INNATE_TRAIT)
 
 /mob/living/basic/zulo/mind_initialize()
 	. = ..()
-	var/preffered_form = client?.prefs.read_preference(/datum/preference/choiced/subsplat/zulo_form)
+	var/preffered_form = client?.prefs.read_preference(/datum/preference/choiced/zulo_form)
 	var/new_icon_state = GLOB.zulo_forms[preffered_form]
 	icon_state = new_icon_state ? new_icon_state : "fiend"

--- a/modular_darkpack/modules/powers/code/discipline/vicissitude/zulo_preferences.dm
+++ b/modular_darkpack/modules/powers/code/discipline/vicissitude/zulo_preferences.dm
@@ -1,12 +1,14 @@
-/datum/preference/choiced/subsplat/zulo_form
+/datum/preference/choiced/zulo_form
 	savefile_key = "zulo_form"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_FEATURES
 	priority = PREFERENCE_PRIORITY_REQUIRES_SUBSPLAT
 	main_feature_name = "Zulo Form"
+	relevant_inherent_trait = TRAIT_VTM_CLANS
+	must_have_relevant_trait = TRUE
 	should_generate_icons = TRUE
 
-/datum/preference/choiced/subsplat/zulo_form/has_relevant_feature(datum/preferences/preferences)
+/datum/preference/choiced/zulo_form/has_relevant_feature(datum/preferences/preferences)
 	. = ..()
 	if(!.) // Make sure we acctually can select clan in the first place
 		return FALSE
@@ -19,17 +21,17 @@
 			return TRUE
 	return FALSE
 
-/datum/preference/choiced/subsplat/zulo_form/init_possible_values()
+/datum/preference/choiced/zulo_form/init_possible_values()
 	var/list/values = list()
 	for(var/name in GLOB.zulo_forms)
 		values[name] = GLOB.zulo_forms[name]
 	return values
 
-/datum/preference/choiced/subsplat/zulo_form/icon_for(value)
+/datum/preference/choiced/zulo_form/icon_for(value)
 	var/icon_state = GLOB.zulo_forms[value]
 	var/datum/universal_icon/zulo_icon = uni_icon('modular_darkpack/modules/powers/icons/zulo_forms.dmi', icon_state)
 	zulo_icon.scale(32, 32)
 	return zulo_icon
 
-/datum/preference/choiced/subsplat/zulo_form/apply_to_human(mob/living/carbon/human/target, value)
+/datum/preference/choiced/zulo_form/apply_to_human(mob/living/carbon/human/target, value)
 	return


### PR DESCRIPTION

## About The Pull Request
fixes #778

I also removed the subsplat from the prefrences type as zulos are not a subsplat belive it or not.
## Why It's Good For The Game
Humans should not have this preference.
## Changelog
:cl:
fix: Characters who have tzimisce selectected internally will not have a zulo preference if not the proper splat
/:cl:
