### PR TITLE
[MAINTAINERS BEWARE] [REVIEW AT OWN PERIL] [DANGEROUS PR] Fixes stone floors

### DIFF
--- a/modular_darkpack/modules/walls/code/floors.dm
+++ b/modular_darkpack/modules/walls/code/floors.dm
@@ -147,7 +147,7 @@
 
 /turf/open/floor/plating/stone/Initialize(mapload)
 	. = ..()
-	icon_state = "cave[rand(1, 7)]"
+	icon_state = "stone[rand(1, 7)]"
 
 /turf/open/floor/plating/grate
 	name = "grate"


### PR DESCRIPTION

## About The Pull Request

did you know stone floors were meant to random pick from these icons?

<img width="700" height="111" alt="image" src="https://github.com/user-attachments/assets/b184611c-19f1-4c58-be64-b84b9505aa8b" />

I didnt, because it wasnt implemented correctly and instead just used cave floor icons

## Why It's Good For The Game

floor

## Changelog
:cl:
fix: fixed stone floors using cave floor icons
/:cl:
