### PR TITLE
Cleaner behavoir for reusing rolls

### DIFF
--- a/code/__DEFINES/~darkpack/storyteller_dice.dm
+++ b/code/__DEFINES/~darkpack/storyteller_dice.dm
@@ -1,3 +1,4 @@
+#define ROLL_COOLDOWN -2
 #define ROLL_BOTCH -1
 #define ROLL_FAILURE 0
 #define ROLL_SUCCESS 1

--- a/code/__DEFINES/~darkpack/storyteller_dice.dm
+++ b/code/__DEFINES/~darkpack/storyteller_dice.dm
@@ -14,3 +14,8 @@
 #define ROLL_ADMIN "admin"
 /// Output is show to no one and is not logged
 #define ROLL_NONE "none"
+
+/// Time at which the roll was recorded
+#define OLD_ROLL_TIME 1
+/// Dice output of the old roll (roll define or just raw number depending on numerical)
+#define OLD_ROLL_OUTPUT 2

--- a/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
@@ -55,7 +55,7 @@
 	last_output_text = list()
 
 	if(!can_roll(roller))
-		return ROLL_FAILURE
+		return ROLL_COOLDOWN
 
 	var/dice_amount = calculate_used_dice(roller, bonus)
 	var/auto_success_amount = calculate_auto_successes(roller)

--- a/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
@@ -15,7 +15,7 @@
 	var/alert_prefix
 	var/alert_delay
 
-	/// A lazy list of times indexed by a weakref to a mob
+	/// A lazy list of roll results indexed by a weakref to a mob. list(OLD_ROLL_TIME, OLD_ROLL_OUTPUT)
 	var/list/mobs_last_rolled
 	var/reroll_cooldown
 	/// If the roll as a reroll_cooldown, return the mobs stored result if it has one.
@@ -49,7 +49,7 @@
 	if(reroll_cooldown && roll_use_last_result)
 		var/list/old_roll = get_old_roll(roller)
 		if(old_roll)
-			return get_old_roll_result(old_roll)
+			return old_roll[OLD_ROLL_OUTPUT]
 
 	last_sucess_amount = 0
 	last_output_text = list()
@@ -251,7 +251,7 @@
 				continue
 			if(guy != roller)
 				continue
-			if(roll_info[1] + reroll_cooldown > world.time)
+			if(roll_info[OLD_ROLL_TIME] + reroll_cooldown > world.time)
 				return roll_info
 			else
 				mobs_last_rolled.Remove(guy_ref) // Clear rolls that expired
@@ -262,9 +262,6 @@
 		return TRUE
 
 	if(feedback)
-		to_chat(roller, span_warning("You cannot reroll [bumper_text] yet. [round((old_mob_roll[1] + reroll_cooldown - world.time)/10)]s left."))
+		to_chat(roller, span_warning("You cannot reroll [bumper_text] yet. [round((old_mob_roll[OLD_ROLL_TIME] + reroll_cooldown - world.time)/10)]s left."))
 
 	return FALSE
-
-/datum/storyteller_roll/proc/get_old_roll_result(list/old_roll)
-	return old_roll[2]

--- a/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
+++ b/modular_darkpack/modules/storyteller_dice/code/roll_datum.dm
@@ -18,6 +18,8 @@
 	/// A lazy list of times indexed by a weakref to a mob
 	var/list/mobs_last_rolled
 	var/reroll_cooldown
+	/// If the roll as a reroll_cooldown, return the mobs stored result if it has one.
+	var/roll_use_last_result = TRUE
 
 	// Mutable vars to store the outputs of any given roll. Expect everything past here to be mutated between each roll.
 	var/last_sucess_amount
@@ -44,6 +46,11 @@
  * Returns: The sucess of the roll, either a define or the raw amount of sucesses if `numerical = TRUE`
  */
 /datum/storyteller_roll/proc/st_roll(mob/living/roller, atom/target, bonus = 0)
+	if(reroll_cooldown && roll_use_last_result)
+		var/list/old_roll = get_old_roll(roller)
+		if(old_roll)
+			return get_old_roll_result(old_roll)
+
 	last_sucess_amount = 0
 	last_output_text = list()
 
@@ -234,7 +241,8 @@
 		return dice_output[input]
 	*/
 
-/datum/storyteller_roll/proc/can_roll(mob/living/roller, feedback = TRUE)
+
+/datum/storyteller_roll/proc/get_old_roll(mob/living/roller)
 	if(reroll_cooldown && mobs_last_rolled)
 		for(var/datum/weakref/guy_ref, roll_info in mobs_last_rolled)
 			var/mob/living/guy = guy_ref.resolve()
@@ -244,12 +252,19 @@
 			if(guy != roller)
 				continue
 			if(roll_info[1] + reroll_cooldown > world.time)
-				if(roll_info[2] > 0)
-					return TRUE
-					//return roll_info[2] // We really should support directly returning the output..?
-				if(feedback)
-					to_chat(roller, span_warning("You cannot reroll [bumper_text] yet. [round((roll_info[1] + reroll_cooldown - world.time)/10)]s left."))
-				return FALSE
+				return roll_info
+			else
+				mobs_last_rolled.Remove(guy_ref) // Clear rolls that expired
 
-	return TRUE
+/datum/storyteller_roll/proc/can_roll(mob/living/roller, feedback = TRUE)
+	var/list/old_mob_roll = get_old_roll(roller)
+	if(!old_mob_roll)
+		return TRUE
 
+	if(feedback)
+		to_chat(roller, span_warning("You cannot reroll [bumper_text] yet. [round((old_mob_roll[1] + reroll_cooldown - world.time)/10)]s left."))
+
+	return FALSE
+
+/datum/storyteller_roll/proc/get_old_roll_result(list/old_roll)
+	return old_roll[2]


### PR DESCRIPTION

## About The Pull Request
Reworks the stuff for roll cooldowns to just silently return the result if it can rather then, returning out if you failed the roll but making you reroll it if you passed, which is a bit odd.
If it doesnt return the old roll it just generically fails instead. 

Rolls are also now cleared if they pass the roll cool-down, which should cleanup some odd behavior.
## Why It's Good For The Game
better behavoir, should lead to some less weird results
## Changelog
:cl:
refactor: Tweaks how rolls with cool-down use the old results
/:cl:
