### PR TITLE
Fixes masq breaching for every message

### DIFF
--- a/modular_darkpack/modules/masquerade/code/word_checker.dm
+++ b/modular_darkpack/modules/masquerade/code/word_checker.dm
@@ -15,8 +15,8 @@
 		return FALSE
 
 	var/treated_message = translate_language(speaker, message_language, raw_message, spans, message_mods)
-	var/regexed_message = MASQUERADE_FILTER_CHECK(LOWER_TEXT(treated_message))
-	if(length(regexed_message))
+	var/is_breach = MASQUERADE_FILTER_CHECK(LOWER_TEXT(treated_message))
+	if(is_breach)
 		SEND_SIGNAL(src, COMSIG_SEEN_MASQUERADE_VIOLATION, speaker)
 	return TRUE
 
@@ -28,8 +28,8 @@
 			return
 		var/message = compose_message(hearing_args[HEARING_SPEAKER], hearing_args[HEARING_LANGUAGE], hearing_args[HEARING_RAW_MESSAGE], hearing_args[HEARING_RADIO_FREQ], hearing_args[HEARING_RADIO_FREQ_NAME], hearing_args[HEARING_RADIO_FREQ_COLOR], hearing_args[HEARING_SPANS], hearing_args[HEARING_MESSAGE_MODE], FALSE)
 		SSmasquerade.log_phone_message(message, source)
-		var/regexed_message = MASQUERADE_FILTER_CHECK(LOWER_TEXT(hearing_args[HEARING_RAW_MESSAGE]))
-		if(length(regexed_message))
+		var/is_breach = MASQUERADE_FILTER_CHECK(LOWER_TEXT(hearing_args[HEARING_RAW_MESSAGE]))
+		if(is_breach)
 			SEND_SIGNAL(src, COMSIG_SEEN_MASQUERADE_VIOLATION, hearing_args[HEARING_SPEAKER])
 
 #undef MASQUERADE_FILTER_CHECK

--- a/modular_darkpack/modules/masquerade/code/word_checker.dm
+++ b/modular_darkpack/modules/masquerade/code/word_checker.dm
@@ -15,7 +15,8 @@
 		return FALSE
 
 	var/treated_message = translate_language(speaker, message_language, raw_message, spans, message_mods)
-	if(LOWER_TEXT(MASQUERADE_FILTER_CHECK(treated_message)))
+	var/regexed_message = MASQUERADE_FILTER_CHECK(LOWER_TEXT(treated_message))
+	if(length(regexed_message))
 		SEND_SIGNAL(src, COMSIG_SEEN_MASQUERADE_VIOLATION, speaker)
 	return TRUE
 
@@ -27,7 +28,8 @@
 			return
 		var/message = compose_message(hearing_args[HEARING_SPEAKER], hearing_args[HEARING_LANGUAGE], hearing_args[HEARING_RAW_MESSAGE], hearing_args[HEARING_RADIO_FREQ], hearing_args[HEARING_RADIO_FREQ_NAME], hearing_args[HEARING_RADIO_FREQ_COLOR], hearing_args[HEARING_SPANS], hearing_args[HEARING_MESSAGE_MODE], FALSE)
 		SSmasquerade.log_phone_message(message, source)
-		if(MASQUERADE_FILTER_CHECK(LOWER_TEXT(hearing_args[HEARING_RAW_MESSAGE])))
+		var/regexed_message = MASQUERADE_FILTER_CHECK(LOWER_TEXT(hearing_args[HEARING_RAW_MESSAGE]))
+		if(length(regexed_message))
 			SEND_SIGNAL(src, COMSIG_SEEN_MASQUERADE_VIOLATION, hearing_args[HEARING_SPEAKER])
 
 #undef MASQUERADE_FILTER_CHECK


### PR DESCRIPTION

## About The Pull Request
## Why It's Good For The Game
Fixes da code.

Does anyone see the issue?
<img width="1216" height="305" alt="image" src="https://github.com/user-attachments/assets/309cc2af-6101-4786-a0bc-85e90b85f181" />
<img width="1056" height="95" alt="image" src="https://github.com/user-attachments/assets/665a7432-8965-4c35-a41e-7c08beee4451" />

`MASQUERADE_FILTER_CHECK` evaluates to `0` or `1`
The old code actually has lower text in the wrong spot here. it should be before the regex to see if the word is a breach
that's fine tho as it did nothing as the filter check was just `0` or `1` and evaluated in the if statement correctly.
`LOWER_TEXT` wraps that `0` or `1` in a "" making it a string.
Did you know `"0"` does count as truthy?

## Changelog
:cl:
fix: The masquerade will no longer breach from any message spoken near an NPC
/:cl:
