### PR TITLE
Claimable locks tooltip

### DIFF
--- a/_maps/map_files/Vampire/runtimetown.dmm
+++ b/_maps/map_files/Vampire/runtimetown.dmm
@@ -2388,6 +2388,8 @@
 /obj/structure/vampdoor{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/door/access/claimable,
+/obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/techshop)
 "Mg" = (

--- a/modular_darkpack/modules/doors/code/components/door_ownership.dm
+++ b/modular_darkpack/modules/doors/code/components/door_ownership.dm
@@ -11,9 +11,11 @@
 
 /datum/component/door_ownership/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(try_award_key))
+	RegisterSignal(parent, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, PROC_REF(add_context))
 
 /datum/component/door_ownership/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_CLICK_ALT)
+	UnregisterSignal(parent, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM)
 
 /datum/component/door_ownership/proc/try_award_key(atom/source, mob/user)
 	SIGNAL_HANDLER
@@ -75,3 +77,10 @@
 	human.received_ownership_keys += ownership_type
 	qdel(src)
 
+/datum/component/door_ownership/proc/add_context(datum/source, list/context, obj/item/held_item, mob/user)
+	SIGNAL_HANDLER
+
+	if(ishuman(user))
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Claim Keys"
+		return CONTEXTUAL_SCREENTIP_SET
+	return NONE

--- a/modular_darkpack/modules/doors/code/components/door_ownership.dm
+++ b/modular_darkpack/modules/doors/code/components/door_ownership.dm
@@ -6,8 +6,15 @@
 
 	if(istype(parent, /obj/darkpack_car))
 		ownership_type = LOCK_OWNERSHIP_CAR
+		var/obj/darkpack_car/car = parent
+		car.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
 	else if(istype(parent, /obj/structure/vampdoor))
 		ownership_type = LOCK_OWNERSHIP_APARTMENT
+		var/obj/structure/vampdoor/door = parent
+		door.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
+	else
+		return COMPONENT_INCOMPATIBLE
+
 
 /datum/component/door_ownership/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(try_award_key))
@@ -80,7 +87,10 @@
 /datum/component/door_ownership/proc/add_context(datum/source, list/context, obj/item/held_item, mob/user)
 	SIGNAL_HANDLER
 
-	if(ishuman(user))
+	var/mob/living/carbon/human/human_user = astype(user)
+	if(human_user)
+		if(ownership_type in human_user.received_ownership_keys)
+			return NONE
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Claim Keys"
 		return CONTEXTUAL_SCREENTIP_SET
 	return NONE


### PR DESCRIPTION

## About The Pull Request
Only appears if you can actually claim it.
<img width="194" height="105" alt="image" src="https://github.com/user-attachments/assets/72eb40cb-68ab-4f93-ab05-50d999d957ba" />
<img width="164" height="80" alt="image" src="https://github.com/user-attachments/assets/d6f522a0-cd2a-477c-92a9-fa9dc5e24a3f" />
## Why It's Good For The Game
People have universally complained that they down know how to do this (and guestbook)
## Changelog
:cl:
qol: Adds tooltip for claimable doors and cars
/:cl:
