### PR TITLE
Makes humans convert agg damage to brute

### DIFF
--- a/modular_darkpack/master_files/code/modules/mob/living/carbon/human/life.dm
+++ b/modular_darkpack/master_files/code/modules/mob/living/carbon/human/life.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/Life(seconds_per_tick)
 	if(!get_kindred_splat(src))
 		if(prob(5))
-			adjust_agg_loss(-5, TRUE)
+			adjust_agg_loss(-5)
 	. = ..()
 
 	// SPLATS

--- a/modular_darkpack/modules/aggravated_damage/code/damage_procs.dm
+++ b/modular_darkpack/modules/aggravated_damage/code/damage_procs.dm
@@ -26,6 +26,9 @@
 		updatehealth()
 
 /mob/living/carbon/adjust_agg_loss(amount, updating_health = TRUE, forced = FALSE, required_bodytype)
+	if(ismundane(src) && !forced)
+		return adjust_brute_loss(amount, updating_health, forced, required_bodytype)
+
 	if(!can_adjust_agg_loss(amount, forced, required_bodytype))
 		return 0
 	if(amount > 0)


### PR DESCRIPTION

## About The Pull Request

- [ ] Figure out who this is actually meant to apply to.
## Why It's Good For The Game
TTRPG accuracy and humans have very little in the way of healing it.
## Changelog
:cl:
balance: Humans convert agg damage to brute
/:cl:
