### PR TITLE
Upstream blood_curse_rune.dm

### DIFF
--- a/modular_darkpack/modules/ritual_thaumaturgy/rituals/blood_curse_rune.dm
+++ b/modular_darkpack/modules/ritual_thaumaturgy/rituals/blood_curse_rune.dm
@@ -113,7 +113,7 @@
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		if(H.real_name == curse_target)
 			found_target = TRUE
-			H.adjust_agg_loss(25 + activator_bonus) // TFN EDIT ADD - Adds Daimonori Bonus Damage to Blood Curse
+			H.adjust_agg_loss(25 + activator_bonus)
 			playsound(H.loc, 'modular_darkpack/modules/powers/sounds/thaum.ogg', 50, FALSE)
 			to_chat(H, span_warning("You feel dark energy tearing at your very being!"))
 			H.Stun(2)

--- a/modular_darkpack/modules/ritual_thaumaturgy/rituals/blood_curse_rune.dm
+++ b/modular_darkpack/modules/ritual_thaumaturgy/rituals/blood_curse_rune.dm
@@ -113,7 +113,7 @@
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		if(H.real_name == curse_target)
 			found_target = TRUE
-			H.adjust_agg_loss(25)
+			H.adjust_agg_loss(25 + activator_bonus) // TFN EDIT ADD - Adds Daimonori Bonus Damage to Blood Curse
 			playsound(H.loc, 'modular_darkpack/modules/powers/sounds/thaum.ogg', 50, FALSE)
 			to_chat(H, span_warning("You feel dark energy tearing at your very being!"))
 			H.Stun(2)
@@ -142,4 +142,3 @@
 		to_chat(channeler, span_warning("The last heart is consumed, completing the curse ritual!"))
 		channeling = FALSE
 		qdel(src)
-

--- a/modular_darkpack/modules/ritual_thaumaturgy/rituals/blood_curse_rune.dm
+++ b/modular_darkpack/modules/ritual_thaumaturgy/rituals/blood_curse_rune.dm
@@ -142,3 +142,4 @@
 		to_chat(channeler, span_warning("The last heart is consumed, completing the curse ritual!"))
 		channeling = FALSE
 		qdel(src)
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply adds the activator_bonus defined within the blood curse ritual prior to this PR to the damage the curse deals. Upstreaming from https://github.com/The-Final-Nights/The-Final-Nights-Rebase/pull/366

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The daimonori is supposed to buff thaumaturgy damage and from the looks of it, this was intended since someone already defined activator_bonus = thaum_damage_plus and just forgot to add this activator bonus to the curse damage at the end.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Daimonori damage now also applies to the blood curse ritual.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
