### PR TITLE
Standerdizing message interactions

### DIFF
--- a/code/__DEFINES/~darkpack/keybindings.dm
+++ b/code/__DEFINES/~darkpack/keybindings.dm
@@ -11,7 +11,15 @@
 
 // LOOC
 #define COMSIG_KB_CLIENT_LOOC_DOWN "keybinding_client_looc_down"
+#define COMSIG_KB_CLIENT_LOOC_WALLPIERCE_DOWN "keybinding_client_looc_wallpierce_down"
 
 // DO_EMOTES
 #define COMSIG_KB_CLIENT_DO_DOWN "keybinding_client_do_down"
-#define COMSIG_KB_CLIENT_DO_LONGER_DOWN "keybinding_client_do_longer_down"
+
+// SUBTLE_EMOTES
+#define COMSIG_KB_CLIENT_SUBTLE_DOWN "keybinding_client_subtle_down"
+#define COMSIG_KB_CLIENT_SUBTLE_ANITGHOST_DOWN "keybinding_client_subtle_antighost_down"
+
+
+#define VERB_LOOC "LOOC"
+#define VERB_DO "Do"

--- a/code/__DEFINES/~darkpack/keybindings.dm
+++ b/code/__DEFINES/~darkpack/keybindings.dm
@@ -22,4 +22,5 @@
 
 
 #define VERB_LOOC "LOOC"
+#define VERB_LOOC_WALLPIERCE "LOOC (Wallpierce)"
 #define VERB_DO "Do"

--- a/code/__DEFINES/~darkpack/keybindings.dm
+++ b/code/__DEFINES/~darkpack/keybindings.dm
@@ -18,7 +18,7 @@
 
 // SUBTLE_EMOTES
 #define COMSIG_KB_CLIENT_SUBTLE_DOWN "keybinding_client_subtle_down"
-#define COMSIG_KB_CLIENT_SUBTLE_ANITGHOST_DOWN "keybinding_client_subtle_antighost_down"
+#define COMSIG_KB_CLIENT_SUBTLER_ANTIGHOST_DOWN "keybinding_client_subtler_antighost_down"
 
 
 #define VERB_LOOC "LOOC"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -31,7 +31,7 @@
 		owner.hud_used.screen_objects[HUD_MOB_RESIST].icon_state = owner.hud_used.screen_objects[HUD_MOB_RESIST].base_icon_state
 
 /datum/keybinding/living/look_up
-	hotkey_keys = list("P") // DARKPACK EDIT CHANGE - ORIGINAL: hotkey_keys = list("L")
+	hotkey_keys = list("\[")
 	name = "look up"
 	full_name = "Look Up"
 	description = "Look up at the next z-level.  Only works if directly below open space."

--- a/modular_darkpack/modules/do_emotes/code/do_verbs.dm
+++ b/modular_darkpack/modules/do_emotes/code/do_verbs.dm
@@ -6,11 +6,11 @@
 
 	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 
-	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "custom_do", NONE, message, TRUE), SSspeech_controller)
+	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "do", NONE, message, TRUE), SSspeech_controller)
 
 
 /datum/emote/living/custom/do_emote
-	key = "custom_do"
+	key = "do"
 	key_third_person = "custom_do"
 	message = null
 

--- a/modular_darkpack/modules/do_emotes/code/do_verbs.dm
+++ b/modular_darkpack/modules/do_emotes/code/do_verbs.dm
@@ -6,12 +6,12 @@
 
 	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 
-	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "do_emote", NONE, message, TRUE), SSspeech_controller)
+	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "custom_do", NONE, message, TRUE), SSspeech_controller)
 
 
 /datum/emote/living/custom/do_emote
-	key = "do_emote"
-	key_third_person = "do_emote"
+	key = "custom_do"
+	key_third_person = "custom_do"
 	message = null
 
 

--- a/modular_darkpack/modules/do_emotes/code/do_verbs.dm
+++ b/modular_darkpack/modules/do_emotes/code/do_verbs.dm
@@ -1,52 +1,53 @@
-/mob/verb/do_verb()
-	set name = "Do"
-	set hidden = TRUE
+/mob/verb/do_verb(message as text)
+	set name = VERB_DO
 	if(GLOB.say_disabled) // This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
-	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(emote), "do_emote"))
 
-/datum/emote/living/do_emote
+	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+
+	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "do_emote", NONE, message, TRUE), SSspeech_controller)
+
+
+/datum/emote/living/custom/do_emote
 	key = "do_emote"
 	key_third_person = "do_emote"
 	message = null
-	mob_type_blacklist_typecache = list(/mob/living/brain)
 
-/datum/emote/living/do_emote/run_emote(mob/user, params, type_override, intentional)
-	if(!can_run_emote(user))
-		to_chat(user, span_warning("You can't emote at this time."))
-		return FALSE
-	if(SSdbcore.IsConnected() && is_banned_from(user, "Emote"))
-		to_chat(user, span_warning("You cannot send emotes (banned)."))
-		return FALSE
-	else if(user.client?.prefs.muted & MUTE_IC)
-		to_chat(user, span_warning("You cannot send IC messages (muted)."))
-		return FALSE
 
-	var/message = tgui_input_text(user, "Write your do emote.", "Do Emote", null, max_length = MAX_MESSAGE_LEN, multiline = TRUE)
-	if (!message)
+/datum/emote/living/custom/do_emote/run_emote(mob/user, params, type_override, intentional)
+	var/msg = select_message_type(user, message, intentional)
+	if(params)
+		if(message_param)
+			msg = select_param(user, params)
+		else
+			msg = params
+
+	msg = replace_pronoun(user, msg)
+	if(!msg)
 		return
 
-	if (!user.try_speak(message)) // ensure we pass the vibe check (filters, etc)
+
+	if (!user.try_speak(msg)) // ensure we pass the vibe check (filters, etc)
 		return
 
 	var/name_stub = " (<b>[user.name]</b>)"
-	message = trim(copytext_char(message, 1, (MAX_MESSAGE_LEN - length(name_stub))))
-	var/message_with_name = message + name_stub
+	msg = trim(copytext_char(msg, 1, (MAX_MESSAGE_LEN - length(name_stub))))
+	var/message_with_name = msg + name_stub
 
-	user.log_message(message, LOG_EMOTE)
+	user.log_message(msg, LOG_EMOTE)
 
 	var/list/viewers = get_hearers_in_view(DEFAULT_MESSAGE_RANGE, user)
 
 	for(var/mob/ghost as anything in GLOB.dead_mob_list)
 		name_stub = " (<b>[GET_GUESTBOOK_NAME(ghost, user)]</b>)"
-		message_with_name = message + name_stub
+		message_with_name = msg + name_stub
 		if((ghost.client?.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers))
 			to_chat(ghost, "[FOLLOW_LINK(ghost, user)] [span_emote(message_with_name)]")
 
 	for(var/mob/receiver in viewers)
 		name_stub = " (<b>[GET_GUESTBOOK_NAME(receiver, user)]</b>)"
-		message_with_name = message + name_stub
+		message_with_name = msg + name_stub
 		receiver.show_message(span_emote(message_with_name), alt_msg = span_emote(message_with_name))
 		if (receiver.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat))
-			receiver.create_chat_message(user, null, message, null, EMOTE_MESSAGE)
+			receiver.create_chat_message(user, null, msg, null, EMOTE_MESSAGE)

--- a/modular_darkpack/modules/do_emotes/code/keybinds.dm
+++ b/modular_darkpack/modules/do_emotes/code/keybinds.dm
@@ -8,5 +8,10 @@
 	. = ..()
 	if(.)
 		return
-	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(user.mob, TYPE_PROC_REF(/mob, emote), "do_emote"))
+	if(!user.prefs.read_preference(/datum/preference/toggle/tgui_input))
+		winset(user, null, "command=[VERB_DO]")
+		return TRUE
+	winset(user, null, "command=[user.tgui_say_create_open_command(DO_CHANNEL)]")
+	winset(user, "tgui_say.browser", "focus=true")
 	return TRUE
+

--- a/modular_darkpack/modules/looc/code/keybinds.dm
+++ b/modular_darkpack/modules/looc/code/keybinds.dm
@@ -18,7 +18,7 @@
 
 /datum/keybinding/client/communication/looc_wallpierce
 	hotkey_keys = list("ShiftL")
-	name = LOOC_CHANNEL
+	name "LOOC Wallpierce"
 	full_name = "Local OOC Wallpierce (LOOC)"
 	keybind_signal = COMSIG_KB_CLIENT_LOOC_WALLPIERCE_DOWN
 
@@ -26,5 +26,5 @@
 	. = ..()
 	if(.)
 		return
-	user.looc_wallpierce()
+	winset(user, null, "command=[VERB_LOOC_WALLPIERCE]")
 	return TRUE

--- a/modular_darkpack/modules/looc/code/keybinds.dm
+++ b/modular_darkpack/modules/looc/code/keybinds.dm
@@ -18,7 +18,7 @@
 
 /datum/keybinding/client/communication/looc_wallpierce
 	hotkey_keys = list("ShiftL")
-	name "LOOC Wallpierce"
+	name = "LOOC Wallpierce"
 	full_name = "Local OOC Wallpierce (LOOC)"
 	keybind_signal = COMSIG_KB_CLIENT_LOOC_WALLPIERCE_DOWN
 

--- a/modular_darkpack/modules/looc/code/keybinds.dm
+++ b/modular_darkpack/modules/looc/code/keybinds.dm
@@ -8,6 +8,23 @@
 	. = ..()
 	if(.)
 		return
+	if(!user.prefs.read_preference(/datum/preference/toggle/tgui_input))
+		winset(user, null, "command=[VERB_LOOC]")
+		return TRUE
 	winset(user, null, "command=[user.tgui_say_create_open_command(LOOC_CHANNEL)]")
 	winset(user, "tgui_say.browser", "focus=true")
+	return TRUE
+
+
+/datum/keybinding/client/communication/looc_wallpierce
+	hotkey_keys = list("ShiftL")
+	name = LOOC_CHANNEL
+	full_name = "Local OOC Wallpierce (LOOC)"
+	keybind_signal = COMSIG_KB_CLIENT_LOOC_WALLPIERCE_DOWN
+
+/datum/keybinding/client/communication/looc_wallpierce/down(client/user, turf/target, mousepos_x, mousepos_y)
+	. = ..()
+	if(.)
+		return
+	user.looc_wallpierce()
 	return TRUE

--- a/modular_darkpack/modules/looc/code/verbs.dm
+++ b/modular_darkpack/modules/looc/code/verbs.dm
@@ -7,7 +7,7 @@
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(looc_message), msg))
 
 /client/verb/looc_wallpierce(msg as text)
-	set name = "LOOC (Wallpierce)"
+	set name = VERB_LOOC_WALLPIERCE
 	set desc = "Local OOC, seen by anyone within 7 tiles of you."
 
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(looc_message), msg, TRUE))

--- a/modular_darkpack/modules/looc/code/verbs.dm
+++ b/modular_darkpack/modules/looc/code/verbs.dm
@@ -1,16 +1,14 @@
 #define LOOC_RANGE 7
 
 /client/verb/looc(msg as text)
-	set name = "LOOC"
+	set name = VERB_LOOC
 	set desc = "Local OOC, seen only by those in view."
-	set category = "OOC"
 
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(looc_message), msg))
 
 /client/verb/looc_wallpierce(msg as text)
 	set name = "LOOC (Wallpierce)"
 	set desc = "Local OOC, seen by anyone within 7 tiles of you."
-	set category = "OOC"
 
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(looc_message), msg, TRUE))
 

--- a/modular_darkpack/modules/subtle/code/keybinds.dm
+++ b/modular_darkpack/modules/subtle/code/keybinds.dm
@@ -1,0 +1,12 @@
+/datum/keybinding/client/communication/subtle
+	hotkey_keys = list(UNBOUND_KEY)
+	name = LOOC_CHANNEL
+	full_name = "Subtle Emote"
+	keybind_signal = COMSIG_KB_CLIENT_LOOC_WALLPIERCE_DOWN
+
+/datum/keybinding/client/communication/subtle/down(client/user, turf/target, mousepos_x, mousepos_y)
+	. = ..()
+	if(.)
+		return
+	user.mob.subtle_verb()
+	return TRUE

--- a/modular_darkpack/modules/subtle/code/keybinds.dm
+++ b/modular_darkpack/modules/subtle/code/keybinds.dm
@@ -1,12 +1,23 @@
 /datum/keybinding/client/communication/subtle
 	hotkey_keys = list(UNBOUND_KEY)
-	name = LOOC_CHANNEL
 	full_name = "Subtle Emote"
-	keybind_signal = COMSIG_KB_CLIENT_LOOC_WALLPIERCE_DOWN
+	keybind_signal = COMSIG_KB_CLIENT_SUBTLE_DOWN
 
 /datum/keybinding/client/communication/subtle/down(client/user, turf/target, mousepos_x, mousepos_y)
 	. = ..()
 	if(.)
 		return
 	user.mob.subtle_verb()
+	return TRUE
+
+/datum/keybinding/client/communication/subtler
+	hotkey_keys = list(UNBOUND_KEY)
+	full_name = "Subtler Anti-Ghost"
+	keybind_signal = COMSIG_KB_CLIENT_SUBTLER_ANTIGHOST_DOWN
+
+/datum/keybinding/client/communication/subtle/down(client/user, turf/target, mousepos_x, mousepos_y)
+	. = ..()
+	if(.)
+		return
+	user.mob.subtler_verb()
 	return TRUE

--- a/modular_darkpack/modules/subtle/code/keybinds.dm
+++ b/modular_darkpack/modules/subtle/code/keybinds.dm
@@ -1,5 +1,6 @@
 /datum/keybinding/client/communication/subtle
 	hotkey_keys = list(UNBOUND_KEY)
+	name = "Subtle"
 	full_name = "Subtle Emote"
 	keybind_signal = COMSIG_KB_CLIENT_SUBTLE_DOWN
 
@@ -12,10 +13,11 @@
 
 /datum/keybinding/client/communication/subtler
 	hotkey_keys = list(UNBOUND_KEY)
+	name = "Subtler"
 	full_name = "Subtler Anti-Ghost"
 	keybind_signal = COMSIG_KB_CLIENT_SUBTLER_ANTIGHOST_DOWN
 
-/datum/keybinding/client/communication/subtle/down(client/user, turf/target, mousepos_x, mousepos_y)
+/datum/keybinding/client/communication/subtler/down(client/user, turf/target, mousepos_x, mousepos_y)
 	. = ..()
 	if(.)
 		return

--- a/modular_darkpack/modules/subtle/code/subtle.dm
+++ b/modular_darkpack/modules/subtle/code/subtle.dm
@@ -6,11 +6,9 @@
 #define SUBTLE_ONE_TILE_TEXT "1-Tile Range"
 #define SUBTLE_SAME_TILE_TEXT "Same Tile"
 
-/datum/emote/living/subtle
+/datum/emote/living/custom/subtle
 	key = "subtle"
 	key_third_person = "subtle"
-	message = null
-	mob_type_blacklist_typecache = list(/mob/living/brain)
 
 // DARKPACK TODO: Replace to be in line with the rest of our talking sound
 /datum/preference/toggle/subtler_sound
@@ -28,7 +26,7 @@
 /datum/log_category/subtle
 	category = LOG_CATEGORY_SUBTLE
 
-/datum/emote/living/subtle/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/custom/subtle/run_emote(mob/user, params, type_override, intentional)
 	if(!can_run_emote(user))
 		to_chat(user, span_warning("You can't emote at this time."))
 		return FALSE
@@ -87,13 +85,11 @@
 *	SUBTLE 2: NO GHOST BOOGALOO
 */
 
-/datum/emote/living/subtler
+/datum/emote/living/custom/subtler
 	key = "subtler"
 	key_third_person = "subtler"
-	message = null
-	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 
-/datum/emote/living/subtler/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/custom/subtler/run_emote(mob/user, params, type_override, intentional)
 	if(!can_run_emote(user))
 		to_chat(user, span_warning("You can't emote at this time."))
 		return FALSE

--- a/modular_darkpack/modules/subtle/code/subtle.dm
+++ b/modular_darkpack/modules/subtle/code/subtle.dm
@@ -91,7 +91,7 @@
 	key = "subtler"
 	key_third_person = "subtler"
 	message = null
-	mob_type_blacklist_typecache = list(/mob/living/brain)
+	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 
 /datum/emote/living/subtler/run_emote(mob/user, params, type_override, intentional)
 	if(!can_run_emote(user))
@@ -188,25 +188,32 @@
 *	VERB CODE
 */
 
-/mob/living/verb/subtle_verb()
+/mob/verb/subtle_verb(message as text)
 	set name = "Subtle"
-	set category = "IC"
-	if(GLOB.say_disabled)	// This is here to try to identify lag problems
+
+	if(GLOB.say_disabled) //This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
-	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(emote), "subtle"))
+
+	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+
+	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "subtle", NONE, message, TRUE), SSspeech_controller)
 
 /*
 *	VERB CODE 2
 */
 
-/mob/living/verb/subtler_verb()
+/mob/verb/subtler_verb(message as text)
 	set name = "Subtler Anti-Ghost"
-	set category = "IC"
-	if(GLOB.say_disabled)	// This is here to try to identify lag problems
+
+	if(GLOB.say_disabled) //This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
-	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(emote), "subtler"))
+
+	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+
+	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "subtler", NONE, message, TRUE), SSspeech_controller)
+
 
 #undef SUBTLE_DEFAULT_DISTANCE
 #undef SUBTLE_MESSAGE_LEN

--- a/modular_darkpack/modules/subtle/code/subtle.dm
+++ b/modular_darkpack/modules/subtle/code/subtle.dm
@@ -9,6 +9,7 @@
 /datum/emote/living/custom/subtle
 	key = "subtle"
 	key_third_person = "subtle"
+	message = null
 
 // DARKPACK TODO: Replace to be in line with the rest of our talking sound
 /datum/preference/toggle/subtler_sound
@@ -27,28 +28,15 @@
 	category = LOG_CATEGORY_SUBTLE
 
 /datum/emote/living/custom/subtle/run_emote(mob/user, params, type_override, intentional)
-	if(!can_run_emote(user))
-		to_chat(user, span_warning("You can't emote at this time."))
-		return FALSE
 	var/subtle_message
 	var/subtle_emote = params
-	if(SSdbcore.IsConnected() && is_banned_from(user, "Emote"))
-		to_chat(user, "You cannot send subtle emotes (banned).")
-		return FALSE
-	else if(user.client?.prefs.muted & MUTE_IC)
-		to_chat(user, "You cannot send IC messages (muted).")
-		return FALSE
-	else if(!params)
+	if(!params)
 		subtle_emote = tgui_input_text(user, "Choose an emote to display.", "Subtle", null, max_length = SUBTLE_MESSAGE_LEN, multiline = TRUE)
 		if(!subtle_emote)
 			return FALSE
 		subtle_message = subtle_emote
 	else
 		subtle_message = params
-
-	if(!can_run_emote(user))
-		to_chat(user, span_warning("You can't emote at this time."))
-		return FALSE
 
 	user.log_message(subtle_message, LOG_SUBTLE)
 
@@ -88,23 +76,15 @@
 /datum/emote/living/custom/subtler
 	key = "subtler"
 	key_third_person = "subtler"
+	message = null
 
 /datum/emote/living/custom/subtler/run_emote(mob/user, params, type_override, intentional)
-	if(!can_run_emote(user))
-		to_chat(user, span_warning("You can't emote at this time."))
-		return FALSE
 	var/subtler_message
 	var/subtler_emote = params
 	var/target
 	var/subtler_range = SUBTLE_DEFAULT_DISTANCE
 
-	if(SSdbcore.IsConnected() && is_banned_from(user, "Emote"))
-		to_chat(user, span_warning("You cannot send subtle emotes (banned)."))
-		return FALSE
-	else if(user.client?.prefs.muted & MUTE_IC)
-		to_chat(user, span_warning("You cannot send IC messages (muted)."))
-		return FALSE
-	else if(!subtler_emote)
+	if(!subtler_emote)
 		subtler_emote = tgui_input_text(user, "Choose an emote to display.", "Subtler" , max_length = SUBTLE_MESSAGE_LEN, multiline = TRUE)
 		if(!subtler_emote)
 			return FALSE
@@ -139,10 +119,6 @@
 	else
 		target = SUBTLE_ONE_TILE
 		subtler_message = subtler_emote
-
-	if(!can_run_emote(user))
-		to_chat(user, span_warning("You can't emote at this time."))
-		return FALSE
 
 	user.log_message(subtler_message, LOG_SUBTLE)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7865,6 +7865,7 @@
 #include "modular_darkpack\modules\storyteller_stats\code\st_stats\base_type\_pooled.dm"
 #include "modular_darkpack\modules\storyteller_stats\code\st_stats\base_type\_virtue.dm"
 #include "modular_darkpack\modules\subtle\code\chat_helper.dm"
+#include "modular_darkpack\modules\subtle\code\keybinds.dm"
 #include "modular_darkpack\modules\subtle\code\subtle.dm"
 #include "modular_darkpack\modules\taser\code\taser.dm"
 #include "modular_darkpack\modules\toys\code\pigs.dm"


### PR DESCRIPTION

## About The Pull Request
Right now we have about 4 custom verbs that are modifications/alternatives to stuff like looc, me, say, however, not of all them are alike. This tries and make sure they are mossstly the same
## Why It's Good For The Game
really bad user experience to have these feel so diffrent imo.
## Changelog
:cl:
add: Subtle, Subtler, LOOC wallpierce, and Do all have keybinds. They are no longer found in stat-panel tabs.
fix: Do TGUI-Say odes not open a second box when you try and send a message.
fix: All keybinds that open TGUI-Say now respect disabling it and reverting to normal input.
fix: Do keybind opens tgui-say rather then directly attemping to emote
code: Do, Subtle, Subtler, emotes are considered a subtype of normal custom emotes and should inherit some behavior.
/:cl:
