### PR TITLE
Showing flavor text while masked checks the holder not the reader

### DIFF
--- a/modular_darkpack/modules/flavor_text/code/examine.dm
+++ b/modular_darkpack/modules/flavor_text/code/examine.dm
@@ -30,7 +30,7 @@
 	var/nsfw_content = user.client?.prefs.read_preference(/datum/preference/toggle/nsfw_content_pref)
 	var/flavor_text_nsfw = ""
 	var/ooc_notes = ""
-	var/show_flavor_text_when_masked = user.client?.prefs.read_preference(/datum/preference/toggle/show_flavor_text_when_masked)
+	var/show_flavor_text_when_masked = holder_human.client?.prefs.read_preference(/datum/preference/toggle/show_flavor_text_when_masked)
 
 	if(ishuman(holder))
 		var/mob/living/carbon/human/holder_human = holder

--- a/modular_darkpack/modules/flavor_text/code/examine.dm
+++ b/modular_darkpack/modules/flavor_text/code/examine.dm
@@ -30,7 +30,7 @@
 	var/nsfw_content = user.client?.prefs.read_preference(/datum/preference/toggle/nsfw_content_pref)
 	var/flavor_text_nsfw = ""
 	var/ooc_notes = ""
-	var/show_flavor_text_when_masked = holder_human.client?.prefs.read_preference(/datum/preference/toggle/show_flavor_text_when_masked)
+	var/show_flavor_text_when_masked = holder.client?.prefs.read_preference(/datum/preference/toggle/show_flavor_text_when_masked)
 
 	if(ishuman(holder))
 		var/mob/living/carbon/human/holder_human = holder


### PR DESCRIPTION

## About The Pull Request
its meant to be a pref for people to have there character pref visible if they always are wearing masks, not for someone ELSE to use it to pierce through everyone elses obscuring.
## Why It's Good For The Game
sigh.
## Changelog
:cl:
fix: Showing flavor text while masked checks the holder not the reader
/:cl:
