### PR TITLE
Minor styling on some minor elements

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -6,7 +6,7 @@
 
 // The default UI style is the first one in the list
 GLOBAL_LIST_INIT(available_ui_styles, list(
-	"World of Darkness" = 'modular_darkpack/master_files/icons/hud/screen_darkness_new.dmi', // DARKPACK EDIT ADD - (Put at the top because it has almost full coverage now!)
+	"World-of-Darkness" = 'modular_darkpack/master_files/icons/hud/screen_darkness_new.dmi', // DARKPACK EDIT ADD - (Put at the top because it has almost full coverage now!)
 	"Pentex-Knox" = 'modular_darkpack/master_files/icons/hud/screen_pentexknox.dmi', // DARKPACK EDIT ADD - (Trasen-Knox logo with a Pentex logo)
 	/* // DARKPACK EDIT REMOVAL
 	"Midnight" = 'icons/hud/screen_midnight.dmi',

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1233,6 +1233,12 @@
 				outline_color = COLOR_THEME_TRASENKNOX
 			if("detective")
 				outline_color = COLOR_THEME_DETECTIVE
+			// DARKPACK EDIT ADD START
+			if("pentex-knox")
+				outline_color = COLOR_THEME_TRASENKNOX
+			if("world-of-darkness")
+				outline_color = COLOR_WHITE
+			// DARKPACK EDIT ADD END
 			else //this should never happen, hopefully
 				outline_color = COLOR_WHITE
 	if(color)

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -196,6 +196,7 @@
         background-color: #221c1a;
       }
 
+      /* DARKPACK EDIT ADD START */
       .pentex-knox .wrap {
         border-color: #998e81;
       }
@@ -214,6 +215,7 @@
         border-color: #07060c;
         background-color: #101419;
       }
+      /* DARKPACK EDIT ADD END */
 
     </style>
   </head>

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -206,7 +206,6 @@
         background-color: #1e1d21;
       }
 
-
       .world-of-darkness .wrap {
         border-color: #07060c;
       }

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -195,6 +195,26 @@
         border-color: #2c0f0c;
         background-color: #221c1a;
       }
+
+      .pentex-knox .wrap {
+        border-color: #998e81;
+      }
+      .pentex-knox .content {
+        color: #3ce375;
+        border-color: #998e81;
+        background-color: #1e1d21;
+      }
+
+
+      .world-of-darkness .wrap {
+        border-color: #07060c;
+      }
+      .world-of-darkness .content {
+        color: #a39a9a;
+        border-color: #07060c;
+        background-color: #101419;
+      }
+
     </style>
   </head>
   <body>


### PR DESCRIPTION

## About The Pull Request
Item outlines and tooltips now have themes that match our two current huds.

<img width="448" height="193" alt="image" src="https://github.com/user-attachments/assets/0902b21d-0bdc-41da-aec4-c68ca6293e2f" />

<img width="325" height="163" alt="image" src="https://github.com/user-attachments/assets/a35b98ce-4c5d-486e-bfaf-389e0a34b247" />

## Why It's Good For The Game
Ugly
<img width="351" height="186" alt="image" src="https://github.com/user-attachments/assets/975785ae-f715-4539-98de-c169d91cf345" />

## Changelog
:cl:
add: Item outlines and tooltips now match colors of the huds we use.
/:cl:
