### PR TITLE
Grocery Store Spaghetti

### DIFF
--- a/modular_darkpack/modules/retail/code/stores/grocery_store.dm
+++ b/modular_darkpack/modules/retail/code/stores/grocery_store.dm
@@ -10,7 +10,7 @@
 		new /datum/data/vending_product("summer thaw", /obj/item/reagent_containers/cup/soda_cans/summer_thaw),
 		new /datum/data/vending_product("milk", /obj/item/reagent_containers/condiment/milk),
 		new /datum/data/vending_product("bread", /obj/item/food/bread/plain, 8),
-		new /datum/data/vending_product("spaghetti", /obj/item/food/spaghetti, 6),
+		new /datum/data/vending_product("spaghetti", /obj/item/food/spaghetti/raw, 6),
 		new /datum/data/vending_product("tomato", /obj/item/food/grown/tomato),
 		new /datum/data/vending_product("cabbage", /obj/item/food/grown/cabbage),
 		new /datum/data/vending_product("garlic", /obj/item/food/grown/garlic),


### PR DESCRIPTION

## About The Pull Request
Fixes the grocery store giving you an abstract food item instead of normal spaghetti.
## Why It's Good For The Game
Stores dispensing an abstract item seems unintended.
## Changelog
:cl:
fix: grocery store sells real spaghetti
/:cl:
