### PR TITLE
Clan and Tribe keys wont spawn if the map does not have any corresponding doors

### DIFF
--- a/modular_darkpack/modules/cars/code/car.dm
+++ b/modular_darkpack/modules/cars/code/car.dm
@@ -124,6 +124,9 @@
 		access = "[rand(1,9999999)]"
 		AddComponent(/datum/component/door_ownership)
 
+	if(mapload)
+		GLOB.city_door_lock_ids |= access
+
 	// DARKPACK TODO - see about reimplementing this sprite for cars
 	/*
 	headlight_image = new(src)

--- a/modular_darkpack/modules/doors/code/helpers/door_access.dm
+++ b/modular_darkpack/modules/doors/code/helpers/door_access.dm
@@ -6,6 +6,7 @@
 
 /obj/effect/mapping_helpers/door/access/payload(obj/structure/vampdoor/payload)
 	payload.lock_id = lock_id
+	GLOB.city_door_lock_ids |= lock_id
 
 /obj/effect/mapping_helpers/door/access/all
 	name = "all access"

--- a/modular_darkpack/modules/doors/code/keys/keys.dm
+++ b/modular_darkpack/modules/doors/code/keys/keys.dm
@@ -1,4 +1,4 @@
-GLOBAL_LIST_INIT(key_access_by_types, init_key_access_by_types())
+GLOBAL_LIST_INIT(key_access_on_map, init_key_access_by_types())
 GLOBAL_LIST_INIT(city_door_lock_ids, list())
 
 /// Builds a list of the access locks because we cant pull lists from un initlizied keys and we dont want to qdel a key for every spawn.
@@ -6,17 +6,20 @@ GLOBAL_LIST_INIT(city_door_lock_ids, list())
 	var/list/keys_by_type = list()
 	for(var/subtype in valid_subtypesof(/obj/item/vamp/keys))
 		var/obj/item/vamp/keys/temp_key = new()
-		keys_by_type[subtype] = temp_key.accesslocks
+
+		var/matching_door = FALSE
+		for(var/access in temp_key.accesslocks)
+			if(access in temp_key.accesslocks)
+				matching_door = TRUE
+				break
+
+		keys_by_type[subtype] = matching_door
 		qdel(temp_key)
 
 	return keys_by_type
 
 /proc/key_has_matching_door(key_type)
-	for(var/access in GLOB.key_access_by_types[key_type])
-		if(access in GLOB.city_door_lock_ids)
-			return TRUE
-
-	return FALSE
+	return GLOB.key_access_on_map[key_type]
 
 
 /obj/item/vamp/keys

--- a/modular_darkpack/modules/doors/code/keys/keys.dm
+++ b/modular_darkpack/modules/doors/code/keys/keys.dm
@@ -1,3 +1,24 @@
+GLOBAL_LIST_INIT(key_access_by_types, init_key_access_by_types())
+GLOBAL_LIST_EMPTY(city_door_lock_ids)
+
+/// Builds a list of the access locks because we cant pull lists from un initlizied keys and we dont want to qdel a key for every spawn.
+/proc/init_key_access_by_types()
+	var/list/keys_by_type = list()
+	for(var/subtype in valid_subtypesof(/obj/item/vamp/keys))
+		var/obj/item/vamp/keys/temp_key = new()
+		keys_by_type[subtype] = temp_key.accesslocks
+		qdel(temp_key)
+
+	return keys_by_type
+
+/proc/key_has_matching_door(key_type)
+	for(var/access in GLOB.key_access_by_types[key_type])
+		if(access in GLOB.city_door_lock_ids)
+			return TRUE
+
+	return FALSE
+
+
 /obj/item/vamp/keys
 	name = "keys"
 	desc = "Those can open some doors."

--- a/modular_darkpack/modules/doors/code/keys/keys.dm
+++ b/modular_darkpack/modules/doors/code/keys/keys.dm
@@ -1,5 +1,5 @@
 GLOBAL_LIST_INIT(key_access_by_types, init_key_access_by_types())
-GLOBAL_LIST_EMPTY(city_door_lock_ids)
+GLOBAL_LIST_INIT(city_door_lock_ids, list())
 
 /// Builds a list of the access locks because we cant pull lists from un initlizied keys and we dont want to qdel a key for every spawn.
 /proc/init_key_access_by_types()

--- a/modular_darkpack/modules/doors/code/keys/keys.dm
+++ b/modular_darkpack/modules/doors/code/keys/keys.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_INIT(city_door_lock_ids, list())
 
 		var/matching_door = FALSE
 		for(var/access in temp_key.accesslocks)
-			if(access in temp_key.accesslocks)
+			if(access in GLOB.city_door_lock_ids)
 				matching_door = TRUE
 				break
 

--- a/modular_darkpack/modules/doors/code/keys/keys.dm
+++ b/modular_darkpack/modules/doors/code/keys/keys.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_INIT(city_door_lock_ids, list())
 /proc/init_key_access_by_types()
 	var/list/keys_by_type = list()
 	for(var/subtype in valid_subtypesof(/obj/item/vamp/keys))
-		var/obj/item/vamp/keys/temp_key = new()
+		var/obj/item/vamp/keys/temp_key = new subtype()
 		keys_by_type[subtype] = temp_key.accesslocks
 		qdel(temp_key)
 

--- a/modular_darkpack/modules/doors/code/keys/keys.dm
+++ b/modular_darkpack/modules/doors/code/keys/keys.dm
@@ -1,4 +1,4 @@
-GLOBAL_LIST_INIT(key_access_on_map, init_key_access_by_types())
+GLOBAL_LIST_INIT(key_access_by_types, init_key_access_by_types())
 GLOBAL_LIST_INIT(city_door_lock_ids, list())
 
 /// Builds a list of the access locks because we cant pull lists from un initlizied keys and we dont want to qdel a key for every spawn.
@@ -6,20 +6,17 @@ GLOBAL_LIST_INIT(city_door_lock_ids, list())
 	var/list/keys_by_type = list()
 	for(var/subtype in valid_subtypesof(/obj/item/vamp/keys))
 		var/obj/item/vamp/keys/temp_key = new()
-
-		var/matching_door = FALSE
-		for(var/access in temp_key.accesslocks)
-			if(access in GLOB.city_door_lock_ids)
-				matching_door = TRUE
-				break
-
-		keys_by_type[subtype] = matching_door
+		keys_by_type[subtype] = temp_key.accesslocks
 		qdel(temp_key)
 
 	return keys_by_type
 
 /proc/key_has_matching_door(key_type)
-	return GLOB.key_access_on_map[key_type]
+	for(var/access in GLOB.key_access_by_types[key_type])
+		if(access in GLOB.city_door_lock_ids)
+			return TRUE
+
+	return FALSE
 
 
 /obj/item/vamp/keys

--- a/modular_darkpack/modules/doors/code/vampdoor.dm
+++ b/modular_darkpack/modules/doors/code/vampdoor.dm
@@ -41,6 +41,9 @@
 /obj/structure/vampdoor/Initialize(mapload)
 	. = ..()
 
+	if(mapload)
+		GLOB.city_door_lock_ids |= lock_id
+
 	register_context()
 
 	var/static/list/loc_connections = list(

--- a/modular_darkpack/modules/splats/code/subsplat/_subsplat.dm
+++ b/modular_darkpack/modules/splats/code/subsplat/_subsplat.dm
@@ -21,8 +21,8 @@
 	/// ID for trait sources and whatnot
 	var/id
 
-	/// Keys for this subsplats's exclusive hideout
-	var/subsplat_keys
+	/// Typepath of keys for this subsplats's exclusive hideout
+	var/obj/item/vamp/keys/subsplat_keys
 
 /datum/subsplat/proc/on_gain(mob/living/carbon/human/gaining_mob, datum/splat/gaining_splat, joining_round)
 	SHOULD_CALL_PARENT(TRUE)
@@ -62,7 +62,7 @@
 
 	SHOULD_CALL_PARENT(TRUE)
 
-	if(subsplat_keys)
+	if(subsplat_keys && key_has_matching_door(subsplat_keys))
 		joining.put_in_r_hand(new subsplat_keys(joining))
 
 	UnregisterSignal(joining, COMSIG_MOB_LOGIN)

--- a/modular_darkpack/modules/splats/code/subsplat/_subsplat.dm
+++ b/modular_darkpack/modules/splats/code/subsplat/_subsplat.dm
@@ -23,6 +23,8 @@
 
 	/// Typepath of keys for this subsplats's exclusive hideout
 	var/obj/item/vamp/keys/subsplat_keys
+	/// If we check the list of ids of city doors before granting the subsplat key
+	var/check_doors_for_keys = TRUE
 
 /datum/subsplat/proc/on_gain(mob/living/carbon/human/gaining_mob, datum/splat/gaining_splat, joining_round)
 	SHOULD_CALL_PARENT(TRUE)
@@ -62,7 +64,7 @@
 
 	SHOULD_CALL_PARENT(TRUE)
 
-	if(subsplat_keys && key_has_matching_door(subsplat_keys))
+	if(subsplat_keys && check_doors_for_keys && key_has_matching_door(subsplat_keys))
 		joining.put_in_r_hand(new subsplat_keys(joining))
 
 	UnregisterSignal(joining, COMSIG_MOB_LOGIN)


### PR DESCRIPTION

## About The Pull Request
Subsplat keys wont be handed out if NO doors exist on the map that they could unlock. This only includes maploaded doors and wouldn't affect content that spawns POST players joining (hence the addition of a flag that ignores this behavoir)
## Why It's Good For The Game
This wont cover all cases of not wanting someone to have keys, but for most use-cases of just "we dont have a hideout on this map" this should cover most cases and prevent players ahelping "hey where do theses keys go" just for you to have to say nowhere.

Its also alot more programtic and modular then having to edit keys out on the downstream.
And has the bonus on allowing multiple maps to be used that might have different doors on the map.
## Changelog
:cl:
qol: Clan and Tribe keys wont spawn if the map does not have any corresponding doors
/:cl:
