### PR TITLE
Sense the Sin Fix

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/daimonion/daimonion.dm
+++ b/modular_darkpack/modules/powers/code/discipline/daimonion/daimonion.dm
@@ -60,7 +60,7 @@
 		var/target_sense_the_sin_weakness = target_clan.sense_the_sin_text
 		baali_get_stolen_disciplines(target, owner)
 		if(target_sense_the_sin_weakness)
-			to_chat(target, span_notice("[target.name] [target_sense_the_sin_weakness]"))
+			to_chat(owner, span_notice("[target.name] [target_sense_the_sin_weakness]"))
 	/* DARKPACK TODO - bloodbonds
 	if(isghoul(target))
 		var/mob/living/carbon/human/ghoul = target


### PR DESCRIPTION

## About The Pull Request

Fixes an error in Sense the Sin which outputs weaknesses to the target instead of the user.

## Why It's Good For The Game

Bugfix.

## Changelog

:cl:
fix: Fixes Sense the Sin outputting text to target instead of user.
/:cl:
