### PR TITLE
Door bash distance is based on strength

### DIFF
--- a/modular_darkpack/modules/doors/code/vampdoor.dm
+++ b/modular_darkpack/modules/doors/code/vampdoor.dm
@@ -118,15 +118,17 @@
 	. = ..()
 	fix_door()
 
-/obj/structure/vampdoor/proc/break_door(mob/user)
+/obj/structure/vampdoor/proc/break_door(mob/living/user)
 	if(door_broken)
 		return FALSE
 	playsound(get_turf(src), 'modular_darkpack/master_files/sounds/effects/door/get_bent.ogg', 100, FALSE)
 	var/obj/item/shield/door/broken_door = new(get_turf(src))
 	broken_door.icon_state = base_icon_state
 	if(user)
+		var/strength_dots = user.st_get_stat(STAT_STRENGTH)
+		var/throw_distance = clamp(rand(strength_dots - 1, strength_dots + 1) - bash_successes_needed, 0, 5)
 		var/atom/throw_target = get_edge_target_turf(src, user.dir)
-		broken_door.throw_at(throw_target, rand(2, 4), 4, user)
+		broken_door.throw_at(throw_target, throw_distance, 4, user)
 	name = "door frame"
 	desc = "An empty door frame. Someone removed the door by force. A special door repair kit should be able to fix this."
 	door_broken = TRUE

--- a/modular_darkpack/modules/doors/code/vampdoor.dm
+++ b/modular_darkpack/modules/doors/code/vampdoor.dm
@@ -166,7 +166,8 @@
 	set_density(FALSE)
 	set_opacity(FALSE)
 	layer = OPEN_DOOR_LAYER
-	to_chat(user, span_notice("You open [src]."))
+	if(user)
+		to_chat(user, span_notice("You open [src]."))
 	closed = FALSE
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_OPEN)
 

--- a/modular_darkpack/modules/doors/code/vampdoor.dm
+++ b/modular_darkpack/modules/doors/code/vampdoor.dm
@@ -166,8 +166,7 @@
 	set_density(FALSE)
 	set_opacity(FALSE)
 	layer = OPEN_DOOR_LAYER
-	if(user)
-		to_chat(user, span_notice("You open [src]."))
+	to_chat(user, span_notice("You open [src]."))
 	closed = FALSE
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_OPEN)
 


### PR DESCRIPTION

## About The Pull Request
Scales how far the door flies based on strength

(5 dots vs 1) 
<img width="939" height="992" alt="image" src="https://github.com/user-attachments/assets/c451f00e-104b-4d4a-bb4d-f33e3942548a" />
## Why It's Good For The Game
Makes a low strength character getting a lucky roll feel more believable. It subtracts based on successes needed so bigger heavier doors also fly shorter distances.
## Changelog
:cl:
balance: Bashing a door of its hinges scales distance thrown based on strength and roll difficulty
/:cl:
