### PR TITLE
ARMOIRES AND ARMORS - Making Crossbows Useful Again + Leopoldite Plate Armor Buff

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -500,7 +500,7 @@
 	icon_state = "knight_green"
 	inhand_icon_state = "knight_helmet"
 	armor_type = /datum/armor/helmet_knight
-	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = NONE
 	strip_delay = 8 SECONDS
@@ -512,12 +512,13 @@
 	AddElement(/datum/element/adjust_fishing_difficulty, 3)
 
 /datum/armor/helmet_knight
-	melee = 50
-	bullet = 10
+	melee = 75
+	bullet = 50
 	laser = 10
 	energy = 10
 	fire = 80
 	acid = 80
+	wound = 25
 
 /obj/item/clothing/head/helmet/knight/blue
 	icon_state = "knight_blue"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -308,13 +308,13 @@
 	AddComponent(/datum/component/item_equipped_movement_rustle)
 
 /datum/armor/armor_riot
-	melee = 50
-	bullet = 10
+	melee = 75
+	bullet = 50
 	laser = 10
 	energy = 10
 	fire = 80
 	acid = 80
-	wound = 20
+	wound = 30
 
 /obj/item/clothing/suit/armor/balloon_vest
 	name = "balloon vest"

--- a/modular_darkpack/modules/weapons/code/ammo_casings.dm
+++ b/modular_darkpack/modules/weapons/code/ammo_casings.dm
@@ -159,7 +159,7 @@
 	name = "bolt"
 	desc = "Welcome to the Middle Ages!"
 	projectile_type = /obj/projectile/bullet/crossbow_bolt
-	caliber = CALIBER_FOAM
+	caliber = CALIBER_CROSSBOWBOLT
 	icon_state = "arrow"
 	icon = 'modular_darkpack/modules/weapons/icons/ammo.dmi'
 	ONFLOOR_ICON_HELPER('modular_darkpack/modules/weapons/icons/ammo_onfloor.dmi')

--- a/modular_darkpack/modules/weapons/code/projectiles.dm
+++ b/modular_darkpack/modules/weapons/code/projectiles.dm
@@ -188,7 +188,7 @@
 // Crossbow Bolt
 /obj/projectile/bullet/crossbow_bolt
 	name = "bolt"
-	damage = 45
+	damage = 90
 	armour_penetration = 75
 	sharpness = SHARP_POINTY
 

--- a/modular_darkpack/modules/weapons/code/projectiles.dm
+++ b/modular_darkpack/modules/weapons/code/projectiles.dm
@@ -188,9 +188,22 @@
 // Crossbow Bolt
 /obj/projectile/bullet/crossbow_bolt
 	name = "bolt"
-	damage = 90
+	damage = 45
 	armour_penetration = 75
+	exposed_wound_bonus = 30
+	wound_bonus = 30 //We're gonna make this hurt as much as possible. 
 	sharpness = SHARP_POINTY
+	embed_type = /datum/embedding/crossbolt //YEEEEOUCH!!!!
+
+/datum/embedding/crossbolt
+	embed_chance = 90
+	fall_chance = 2
+	jostle_chance = 2
+	ignore_throwspeed_threshold = TRUE
+	pain_stam_pct = 0.5
+	pain_mult = 3
+	jostle_pain_mult = 3
+	rip_time = 3 SECONDS
 
 // 7.62x51mm NATO
 /obj/projectile/bullet/darkpack/vamp762x51mm


### PR DESCRIPTION

## About The Pull Request
Fixes the ever-present reload bug on the Crossbow. Also partially-returned the bolt's damage back to what it used to be. 
I've also made the full suits of plate armor in the Leopoldite sanctuary _actually_ protect you from conventional forms of damage. It's plate armor, you should be able to deflect melee blows better than a kevlar vest, right?
## Why It's Good For The Game
Crossbows were relegated to decorative garbage due to the massive projectile nerf, and the reload bug that soon followed. This will remedy that issue and add another weapon into our diversity pool. 
The plate armor in the Leopoldite armory is just... a base SS13 set of plate armor, and it has become a bit of a meme due to how comically low their protection values are relative to the rest of the armor in the game. Note - a _leather trenchcoat_ can deflect bullets better than the plate armor. That's nuts. 
## Changelog
:cl:
balance: buffed the bolt projectile and leopoldite armor a bit.
fix: fixed the crossbow reloading issue

/:cl:
