### PR TITLE
Tweaks to Melee roll display and calculation

### DIFF
--- a/code/__DEFINES/~darkpack/combat.dm
+++ b/code/__DEFINES/~darkpack/combat.dm
@@ -12,6 +12,10 @@
 // Heavy placeholder to represent that lethal is ... twice as bad as bashing (brute basiclly)
 #define LETHAL_TTRPG_DAMAGE * 20
 
+#define FORCE_TO_DICE_POOL(force) round(force / (1 TTRPG_DAMAGE))
+#define FORCE_TO_DICE_POOL_UNROUNDED(force) (force / (1 TTRPG_DAMAGE))
+#define LEFTOVER_FORCE_TO_PERECENT(force) ((force % (1 TTRPG_DAMAGE) / (1 TTRPG_DAMAGE)) * 100)
+
 // Unused for now
 #define BASHING "bashing"
 #define LETHAL "lethal"

--- a/code/__DEFINES/~darkpack/combat.dm
+++ b/code/__DEFINES/~darkpack/combat.dm
@@ -14,7 +14,7 @@
 
 #define FORCE_TO_DICE_POOL(force) round(force / (1 TTRPG_DAMAGE))
 #define FORCE_TO_DICE_POOL_UNROUNDED(force) (force / (1 TTRPG_DAMAGE))
-#define LEFTOVER_FORCE_TO_PERECENT(force) ((force % (1 TTRPG_DAMAGE) / (1 TTRPG_DAMAGE)) * 100)
+#define LEFTOVER_FORCE_TO_PERCENT(force) ((force % (1 TTRPG_DAMAGE) / (1 TTRPG_DAMAGE)) * 100)
 
 // Unused for now
 #define BASHING "bashing"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -317,7 +317,7 @@
 	// This means we can do stuff like set force of a baseball bat to 2 TTRPG_DAM and it just works.
 	if(isliving(user) && !HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER) && (final_force >= 1 TTRPG_DAMAGE))
 		var/bonus_dice = FORCE_TO_DICE_POOL(final_force)
-		if(prob(LEFTOVER_FORCE_TO_PERECENT(final_force)))
+		if(prob(LEFTOVER_FORCE_TO_PERCENT(final_force)))
 			bonus_dice++
 		var/datum/storyteller_roll/damage/damage_roll = new()
 		damage_roll.applicable_stats = list(attacking_item.st_damage_stat)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -315,8 +315,10 @@
 	// DARKPACK EDIT ADD START - STORYTELLER_ROLLS/STORYTELLER_STATS
 	// This is pretty evil, but we are gonna convert all the tg force into the +# that melee weapons have listed.
 	// This means we can do stuff like set force of a baseball bat to 2 TTRPG_DAM and it just works.
-	if(isliving(user) && !HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER))
-		var/bonus_dice = round(final_force / (1 TTRPG_DAMAGE))
+	if(isliving(user) && !HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER) && (final_force >= 1 TTRPG_DAMAGE))
+		var/bonus_dice = FORCE_TO_DICE_POOL(final_force)
+		if(prob(LEFTOVER_FORCE_TO_PERECENT(final_force)))
+			bonus_dice++
 		var/datum/storyteller_roll/damage/damage_roll = new()
 		damage_roll.applicable_stats = list(attacking_item.st_damage_stat)
 		var/damage_roll_result = damage_roll.st_roll(user, src, bonus_dice)
@@ -363,7 +365,7 @@
 		final_force *= attacking_item.get_demolition_modifier(src)
 
 	// DARKPACK EDIT ADD START - STORYTELLER_ROLLS/STORYTELLER_STATS
-	if(isliving(user) && !HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER))
+	if(isliving(user) && !HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER) && (final_force >= 1 TTRPG_DAMAGE))
 		var/datum/storyteller_roll/attack/attack_roll = new()
 		attack_roll.applicable_stats = list(attacking_item.st_attack_ability, attacking_item.st_attack_attribute)
 		attack_roll.difficulty = attacking_item.attack_difficulty
@@ -373,7 +375,9 @@
 		if(attack_roll_result == ROLL_SUCCESS)
 			// This is pretty evil, but we are gonna convert all the tg force into the +# that melee weapons have listed.
 			// This means we can do stuff like set force of a baseball bat to 2 TTRPG_DAM and it just works.
-			var/bonus_dice = round(final_force / (1 TTRPG_DAMAGE))
+			var/bonus_dice = FORCE_TO_DICE_POOL(final_force)
+			if(prob(LEFTOVER_FORCE_TO_PERECENT(final_force)))
+				bonus_dice++
 			var/datum/storyteller_roll/damage/damage_roll = new()
 			damage_roll.applicable_stats = list(attacking_item.st_damage_stat)
 			var/damage_roll_result = damage_roll.st_roll(user, src, bonus_dice)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -376,7 +376,7 @@
 			// This is pretty evil, but we are gonna convert all the tg force into the +# that melee weapons have listed.
 			// This means we can do stuff like set force of a baseball bat to 2 TTRPG_DAM and it just works.
 			var/bonus_dice = FORCE_TO_DICE_POOL(final_force)
-			if(prob(LEFTOVER_FORCE_TO_PERECENT(final_force)))
+			if(prob(LEFTOVER_FORCE_TO_PERCENT(final_force)))
 				bonus_dice++
 			var/datum/storyteller_roll/damage/damage_roll = new()
 			damage_roll.applicable_stats = list(attacking_item.st_damage_stat)

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -79,7 +79,7 @@
 			readout += "It's pointy and could cause piercing wounds."
 		// DARKPACK EDIT ADD START - STORYTELLER_STATS
 		readout += "It has an attack difficulty of [span_warning("[source.attack_difficulty]")] and uses [source.st_attack_ability::name]+[source.st_attack_attribute::name] to attack."
-		readout += "It has an dice bonus of [span_warning("[FORCE_TO_DICE_POOL_UNROUNDED(source.force)]")] and uses [source.st_damage_stat::name] for damage."
+		readout += "It has a dice bonus of [span_warning("[FORCE_TO_DICE_POOL_UNROUNDED(source.force)]")] and uses [source.st_damage_stat::name] for damage."
 		// DARKPACK EDIT ADD END
 		// Make sure not to divide by 0 on accident
 		if(source.force > 0)

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -77,6 +77,10 @@
 			readout += "It's sharp and could cause bleeding wounds."
 		if (source.get_sharpness() & SHARP_POINTY)
 			readout += "It's pointy and could cause piercing wounds."
+		// DARKPACK EDIT ADD START - STORYTELLER_STATS
+		readout += "It has an attack difficulty of [span_warning("[source.attack_difficulty]")] and uses [source.st_attack_ability::name]+[source.st_attack_attribute::name] to attack."
+		readout += "It has an dice bonus of [span_warning("[FORCE_TO_DICE_POOL_UNROUNDED(source.force)]")] and uses [source.st_damage_stat::name] for damage."
+		// DARKPACK EDIT ADD END
 		// Make sure not to divide by 0 on accident
 		if(source.force > 0)
 			readout += "It takes about [span_warning("[HITS_TO_CRIT(source.force)] melee hit\s")] to take down an enemy."


### PR DESCRIPTION

## About The Pull Request
Some tweaks after a discussion that fixes a few issues weapons have rn

I also made a [TG pr ](https://github.com/tgstation/tgstation/pull/96862) that adds a bunch more information that was not specfic to us, specificly displaying damage type is neat as aggravated damage is alot diffrent to brute/bashing.
(the takes about melee hits thing prob needs to be removed as its hella inaccurate now but throwing still works how it used to so idk what to do with that part of it.)
<img width="514" height="379" alt="image" src="https://github.com/user-attachments/assets/8e93a942-fd72-4833-8a44-750f0f4045a6" />
## Why It's Good For The Game
While I wouldn't recommend it, weapons with decimal amount of bonus dice should have SOME effect probably.
Conveying information is always better imo and helps clear up a little ambiguity with the current system.
And most items below 1 TTRPG_DAMAGE are not a weapon so you shouldn't one shot yourself because you clicked on yourself with a pen but oops your a like, 5 strength 5 melee terrorist.
## Changelog
:cl:
qol: Attack information as it relates to rolls is now displayed in a weapons combat information
qol: Attacking with a weapon BELOW a single bonus dice no longer makes a roll that includes your entire dice pool
balance: Weapons with a dice pool that is not rounded turns the remainder into a chance for a bonus dice.
/:cl:
