### PR TITLE
Notifactions and some text message code

### DIFF
--- a/modular_darkpack/modules/events/code/blackout_event.dm
+++ b/modular_darkpack/modules/events/code/blackout_event.dm
@@ -19,7 +19,7 @@
 	announce_when = 5
 
 /datum/round_event/blackout/announce(fake)
-	endpost_announce("A rolling blackouts are affecting your area due to inclement weather. City workers are delayed due to a wife affected area.")
+	endpost_announce("Rolling blackouts are impacting your area due to inclement weather. City workers are delayed due to widespread outages across the city.")
 
 /datum/round_event/blackout/start()
 	for(var/obj/fusebox/F in GLOB.fuseboxes)

--- a/modular_darkpack/modules/events/code/blackout_event.dm
+++ b/modular_darkpack/modules/events/code/blackout_event.dm
@@ -19,7 +19,7 @@
 	announce_when = 5
 
 /datum/round_event/blackout/announce(fake)
-	endpost_announce("A breaking news notification has appeared on your phone - rolling blackouts are affecting your area due to inclement weather.")
+	endpost_announce("A rolling blackouts are affecting your area due to inclement weather. City workers are delayed due to a wife affected area.")
 
 /datum/round_event/blackout/start()
 	for(var/obj/fusebox/F in GLOB.fuseboxes)

--- a/modular_darkpack/modules/events/code/blackout_event.dm
+++ b/modular_darkpack/modules/events/code/blackout_event.dm
@@ -19,13 +19,7 @@
 	announce_when = 5
 
 /datum/round_event/blackout/announce(fake)
-	priority_announce(
-		"A breaking news notification has appeared on your phone - rolling blackouts are affecting your area due to inclement weather.",
-		"Local BREAKING NEWS Alert",
-		'modular_darkpack/modules/events/sounds/news_notification.ogg',
-		ANNOUNCEMENT_TYPE_PRIORITY,
-		color_override = "red",
-	)
+	endpost_announce("A breaking news notification has appeared on your phone - rolling blackouts are affecting your area due to inclement weather.")
 
 /datum/round_event/blackout/start()
 	for(var/obj/fusebox/F in GLOB.fuseboxes)

--- a/modular_darkpack/modules/events/code/economy_crash_event.dm
+++ b/modular_darkpack/modules/events/code/economy_crash_event.dm
@@ -21,13 +21,6 @@
 
 /datum/round_event/financial_crisis/announce(fake)
 	var/chosen_announcement = "[pick(announcement_messages)] Customers are encouraged to contact the branch during normal business hours between 8:00am and 5:00pm, Monday through Friday."
-	priority_announce(
-		"[chosen_announcement]",
-		"BREAKING Financial News ALERT",
-		'modular_darkpack/modules/events/sounds/news_notification.ogg',
-		ANNOUNCEMENT_TYPE_PRIORITY,
-		color_override = "green",
-	)
 	endpost_announce("[chosen_announcement]", "BianchiBank")
 
 /datum/round_event/financial_crisis/start()

--- a/modular_darkpack/modules/events/code/sarcophagus_event.dm
+++ b/modular_darkpack/modules/events/code/sarcophagus_event.dm
@@ -28,16 +28,12 @@
 /datum/round_event/sarcophagus
 	start_when = 1
 	announce_when = 5
+	announce_chance = 20
 
 /datum/round_event/sarcophagus/announce(fake)
-	if(prob(20))
-		priority_announce(
-			"You receive a notification about a viral Endpost - a respected archaeologist notes that the location of a long-lost Assyrian sarcophagus alongside it's key, which was famously stolen, seems to be in your city according to newly published criminological records tracking the suspected thief.",
-			"Viral News Story",
-			'modular_darkpack/modules/events/sounds/news_notification.ogg',
-			ANNOUNCEMENT_TYPE_PRIORITY,
-			color_override = "yellow",
-		)
+	var/endpost_author = pick("thesupernaturalguy71", "mhaley71", "justplumbin92", "illuminati_truther777", "satanwatch_now")
+	var/endpost_post = pick("saw something soooo weird... :) new video coming soon on my channel", "(the post has an extremely blurry image attached of what looks to be some kind of strange tomb.)")
+	endpost_announce(endpost_post, endpost_author)
 
 /datum/round_event/sarcophagus/start()
 	var/list/landmarks = list()

--- a/modular_darkpack/modules/events/code/szlachta_attack_event.dm
+++ b/modular_darkpack/modules/events/code/szlachta_attack_event.dm
@@ -17,6 +17,7 @@
 /datum/round_event/szlachta
 	start_when = 1
 	announce_when = 5
+	announce_chance = 75
 
 /datum/round_event/szlachta/announce(fake)
 	var/endpost_szlachta_author = pick("thesupernaturalguy71", "mhaley71", "justplumbin92", "illuminati_truther777", "satanwatch_now")

--- a/modular_darkpack/modules/phones/code/_phone.dm
+++ b/modular_darkpack/modules/phones/code/_phone.dm
@@ -265,7 +265,11 @@
 		))
 	data["phone_history"] = phone_history
 
-	data["calling_user"] = get_number_contact_name()
+	var/calling_user = incoming_phone_number ? incoming_phone_number : dialed_number
+	if(calling_user)
+		data["calling_user"] = get_number_contact_name(calling_user)
+	else
+		data["calling_user"] = ""
 
 	data["time"] = server_timestamp("hh:mm", ic_time = TRUE)
 	data["date"] = server_timestamp("Day, Month DD, YYYY", ic_time = TRUE)
@@ -547,7 +551,7 @@
 	if(!contact_number || !message_text)
 		return FALSE
 
-	var/contact_name = get_number_contact_name()
+	var/contact_name = get_number_contact_name(contact_number)
 	var/datum/phone_conversation/conversation = get_conversation(contact_number)
 
 	if(!conversation)
@@ -558,22 +562,20 @@
 
 	var/obj/item/smartphone/receiving_phone = SSphones.get_phone_from_number(contact_number)
 	if(receiving_phone)
-		var/recv_contact_name = receiving_phone.get_number_contact_name()
+		var/recv_contact_name = receiving_phone.get_number_contact_name(sim_card.phone_number)
 		var/datum/phone_conversation/recv_conversation = receiving_phone.get_conversation(sim_card.phone_number)
 		if(!recv_conversation)
 			recv_conversation = new(recv_contact_name, sim_card.phone_number)
 			receiving_phone.conversations += recv_conversation
 		recv_conversation.add_message(message_text, FALSE)
-		addtimer(CALLBACK(receiving_phone, PROC_REF(after_text_received)), rand(2 SECONDS, 6 SECONDS)) //simulate random delay before sending an audible/visible alert
+		addtimer(CALLBACK(receiving_phone, PROC_REF(after_text_received), contact_name, message_text), rand(1 SECONDS, 2 SECONDS)) //simulate random delay before sending an audible/visible alert
 		log_phone("[key_name(usr)] sent a text to [contact_number]: [message_text]", list("sender" = contact_name, "receiver" = recv_contact_name, "message" = message_text))
 	return TRUE
 
 //stuff to do after a text is received
-/obj/item/smartphone/proc/after_text_received()
-	if(ringer) //only play the receive sound if sounds are on
-		playsound(loc, 'modular_darkpack/modules/phones/sounds/text_receive.ogg', 50, TRUE)
-		balloon_alert_to_viewers(message = "New Message!", vision_distance = SAMETILE_MESSAGE_RANGE)
-	return TRUE
+/obj/item/smartphone/proc/after_text_received(contact_name, message_text)
+	// This should support having your notifiactions set to hidden to not show detials without opening the app.
+	receive_notification("Message+", contact_name, message_text)
 
 /obj/item/smartphone/proc/format_conversation(contact_number)
 	var/datum/phone_conversation/conversation = get_conversation(contact_number)

--- a/modular_darkpack/modules/phones/code/endpost_announce.dm
+++ b/modular_darkpack/modules/phones/code/endpost_announce.dm
@@ -1,5 +1,5 @@
 // useful proc to announce events as endposts
-/proc/endpost_announce(body, author = "SF Chronicle Nightly")
+/proc/endpost_announce(body, author = EVIL_NEWS_COMPANY)
 	UNTYPED_LIST_ADD(SSphones.endpost_posts, list(
 		"body" = body,
 		"date" = server_timestamp("Day, Month DD, "),

--- a/modular_darkpack/modules/phones/code/endpost_announce.dm
+++ b/modular_darkpack/modules/phones/code/endpost_announce.dm
@@ -8,3 +8,7 @@
 		//"thumbsup_voters" = list(),
 		//"thumbsdown_voters" = list(),
 	))
+
+	// I dont love this, idealy this should be sending code directly to a /datum/app/ or something and having that handle this behavoir as like a signal.
+	for(var/obj/item/smartphone/listening_phone in GLOB.phones_list)
+		listening_phone.receive_notification("Endpost", author, body)

--- a/modular_darkpack/modules/phones/code/endpost_announce.dm
+++ b/modular_darkpack/modules/phones/code/endpost_announce.dm
@@ -11,4 +11,4 @@
 
 	// I dont love this, idealy this should be sending code directly to a /datum/app/ or something and having that handle this behavoir as like a signal.
 	for(var/obj/item/smartphone/listening_phone in GLOB.phones_list)
-		listening_phone.receive_notification("Endpost", author, body)
+		listening_phone.receive_notification("EndPost", author, body)

--- a/modular_darkpack/modules/phones/code/phone_procs.dm
+++ b/modular_darkpack/modules/phones/code/phone_procs.dm
@@ -18,30 +18,31 @@
 			contacts |= new_phone_contact
 
 // Gets the displayed contact's name if they are in contacts or published. If not, show the number.
-/obj/item/smartphone/proc/get_number_contact_name()
+/obj/item/smartphone/proc/get_number_contact_name(contact_num)
 	var/output_user
-	var/calling = incoming_phone_number
-	if(dialed_number)
-		calling = dialed_number
+	if(!contact_num)
+		CRASH("Trying to get a contact number with a bad input.")
+
 	// Default to the contact name calling the phone.
 	for(var/datum/phonecontact/contact in contacts)
-		if(contact.number == calling)
+		if(contact.number == contact_num)
 			output_user = contact.name
 	// If we dont have a contact name, refer to the published listings.
 	if(!output_user)
 		for(var/contact in SSphones.published_phone_numbers)
-			if(calling == SSphones.published_phone_numbers[contact])
+			if(contact_num == SSphones.published_phone_numbers[contact])
 				output_user = contact
 	// Not in our contacts or published listings? Then resolve to showing the phone number.
 	if(!output_user)
-		output_user = "+" + calling
+		output_user = "+" + contact_num
 	return output_user
 
 // Helper proc to add a history log to the phone's records.
 /obj/item/smartphone/proc/add_phone_call_history(call_type, call_type_tooltip)
 	var/datum/phone_history/new_contact = new()
-	new_contact.name = get_number_contact_name()
-	new_contact.number = dialed_number ? dialed_number : incoming_phone_number
+	var/caller_num = dialed_number ? dialed_number : incoming_phone_number
+	new_contact.name = get_number_contact_name(caller_num)
+	new_contact.number = caller_num
 	new_contact.call_type = call_type
 	new_contact.call_type_tooltip = call_type_tooltip
 	new_contact.time = server_timestamp("hh:mm:ss", ic_time = TRUE)
@@ -157,6 +158,18 @@
 		balloon_alert_to_viewers(pick("zzZz!", "ZZZT!", "zZzZ!", "Zzz...", "zzZ...", "ZzZZT!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	if(ringer)
 		playsound(src, call_sound, 50, TRUE, 0, 2)
+
+// App really ought to be a datum. Whateverrrrr
+/obj/item/smartphone/proc/receive_notification(app, title, body)
+	if(vibration)
+		animate(src, pixel_w = 1, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
+		for(var/i in 1 to VIBRATION_LOOP_DURATION / (0.2 SECONDS)) //desired total duration divided by the iteration duration to give the necessary iteration count
+			animate(pixel_w = -2, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_CONTINUE)
+			animate(pixel_w = 2, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_CONTINUE)
+		animate(pixel_w = -1, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE)
+	if(ringer)
+		playsound(src, 'modular_darkpack/modules/phones/sounds/text_receive.ogg', 50, TRUE, 0, 2) // This could prob use a better notification
+	balloon_alert_to_viewers("[app]:[title]", vision_distance = SAMETILE_MESSAGE_RANGE) // Does this emoji look good ingame? Flip a coin.
 
 #undef VIBRATION_LOOP_DURATION
 

--- a/modular_darkpack/modules/phones/code/phone_procs.dm
+++ b/modular_darkpack/modules/phones/code/phone_procs.dm
@@ -169,7 +169,7 @@
 		animate(pixel_w = -1, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE)
 	if(ringer)
 		playsound(src, 'modular_darkpack/modules/phones/sounds/text_receive.ogg', 50, TRUE, 0, 2) // This could prob use a better notification
-	balloon_alert_to_viewers("[app]:[title]", vision_distance = SAMETILE_MESSAGE_RANGE) // Does this emoji look good ingame? Flip a coin.
+	balloon_alert_to_viewers("[app]:[title]", vision_distance = SAMETILE_MESSAGE_RANGE)
 
 #undef VIBRATION_LOOP_DURATION
 


### PR DESCRIPTION

## About The Pull Request
Endpost and Message+ now use a generic helper for notification.
<img width="1067" height="564" alt="image" src="https://github.com/user-attachments/assets/7b0546bb-04be-4085-a6d4-25a8ba2fb5a8" />

Also had to fix `get_number_contact_name` because it was acctually just raw not working for the existing message code. it was pulling the number from phone call behavoir because someone hardcoded it.

We really out to have a proper notifcation in the phone ui itself but all the phone code is extreamly hardcoded and it needs as hella rework tbh.

Apps not being isolated datums makes me cry. Modular computers are right there...
## Why It's Good For The Game
Notifications are nice.
## Changelog
:cl:
add: Endpost and Message+ now use a generic helper for displaying a notification as a balloon alert.
fix: Text messages properly use the phone numbers for the texters rather then phones
/:cl:
