### PR TITLE
Passive Blood Drain Config Option

### DIFF
--- a/config/darkpack_config.txt
+++ b/config/darkpack_config.txt
@@ -67,3 +67,7 @@ ROLEPLAY_ONLY_MERITS 1
 ## Configs for the type of attack we use when we click at a ranged distance. Only one can be enabled at a time.
 #DIRECTIONAL_COMBAT
 SWING_COMBAT
+
+## Configs for passive bloodpool drain, if this is enabled, then the below timer can be adjusted to make vampires and ghouls lose 1 blood point when the timer is up
+#PASSIVE_BP_DRAIN
+PASSIVE_BP_DRAIN_TIMER 12000

--- a/modular_darkpack/master_files/code/controllers/configuration/entries/darkpack_config_entries.dm
+++ b/modular_darkpack/master_files/code/controllers/configuration/entries/darkpack_config_entries.dm
@@ -7,7 +7,7 @@
 
 /datum/config_entry/flag/passive_bp_drain
 	name = "PASSIVE_BP_DRAIN"
-	default = FALSE // off by default; server owners opt in
+	default = FALSE
 
 /datum/config_entry/number/passive_bp_drain_timer
 	name = "PASSIVE_BP_DRAIN_TIMER"

--- a/modular_darkpack/master_files/code/controllers/configuration/entries/darkpack_config_entries.dm
+++ b/modular_darkpack/master_files/code/controllers/configuration/entries/darkpack_config_entries.dm
@@ -4,3 +4,12 @@
 /// Defines whether the server uses the legacy mentor system with mentors.txt or the SQL system.
 /datum/config_entry/flag/mentor_legacy_system
 	protection = CONFIG_ENTRY_LOCKED
+
+/datum/config_entry/flag/passive_bp_drain
+	name = "PASSIVE_BP_DRAIN"
+	default = FALSE // off by default; server owners opt in
+
+/datum/config_entry/number/passive_bp_drain_timer
+	name = "PASSIVE_BP_DRAIN_TIMER"
+	default = 20 MINUTES
+	min_val = 1 MINUTES

--- a/modular_darkpack/master_files/code/controllers/configuration/entries/darkpack_config_entries.dm
+++ b/modular_darkpack/master_files/code/controllers/configuration/entries/darkpack_config_entries.dm
@@ -6,10 +6,8 @@
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/flag/passive_bp_drain
-	name = "PASSIVE_BP_DRAIN"
 	default = FALSE
 
 /datum/config_entry/number/passive_bp_drain_timer
-	name = "PASSIVE_BP_DRAIN_TIMER"
 	default = 20 MINUTES
 	min_val = 1 MINUTES

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/__vampire_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/__vampire_splat.dm
@@ -2,6 +2,15 @@
 	abstract_type = /datum/splat/vampire
 
 	power_type = /datum/discipline
+	COOLDOWN_DECLARE(passive_bp_drain_cooldown)
+
+
+/datum/splat/vampire/splat_life(seconds_per_tick)
+	if(CONFIG_GET(flag/passive_bp_drain))
+		if(COOLDOWN_FINISHED(src, passive_bp_drain_cooldown))
+			owner.adjust_blood_pool(-1)
+			COOLDOWN_START(src, passive_bp_drain_cooldown, CONFIG_GET(number/passive_bp_drain_timer))
+	return
 
 /datum/splat/vampire/proc/get_discipline_power(datum/discipline_power/discipline_power_type)
 	RETURN_TYPE(/datum/discipline_power)


### PR DESCRIPTION
## About The Pull Request

allows a config flag for passive bloodpoint blood drain for all the vampire splats.

also allows a config number for the ideal timer for the passive bloodpoint drain - here it's set to 20 minutes

## Why It's Good For The Game

requested feature

## Changelog

:cl:
add: adds passive blood drain as a mechanic for vampires and ghouls which can be toggled on in darkpack_config.txt with the default timer of 20 minutes
config: adds passive blood drain config option
config: adds passive blood drain timer config option
/:cl:

