### PR TITLE
Cleans up beastmaster unfriending

### DIFF
--- a/code/__DEFINES/~darkpack/dcs/beastmaster_signals.dm
+++ b/code/__DEFINES/~darkpack/dcs/beastmaster_signals.dm
@@ -1,0 +1,2 @@
+/// Signal to wipe any old beastmaster masters.
+#define COMSIG_MOB_WIPE_BEASTMASTER "mob_wipe_beastmaster"

--- a/modular_darkpack/modules/beastmaster/code/beastmaster_minion_management.dm
+++ b/modular_darkpack/modules/beastmaster/code/beastmaster_minion_management.dm
@@ -9,18 +9,11 @@
 )
 
 /mob/living/carbon/human/proc/add_beastmaster_minion(mob/living/minion_or_type, turf/spawn_location)
-	if(istype(minion_or_type))
-		if(minion_or_type in beastmaster_minions)
-			to_chat(src, span_warning("[minion_or_type] already heads your commands."))
-			return FALSE
-		else
-			minion_or_type.wipe_old_beastmasters()
-
-	//limit of (leadership) + 1
-	var/max_minions = st_get_stat(STAT_LEADERSHIP) + 1
-	if(length(beastmaster_minions) >= max_minions)
-		to_chat(src, span_warning("You cannot control more than [max_minions] minion[max_minions > 1 ? "s" : ""]!"))
+	if(!can_tame_beastmaster_minion(minion_or_type, TRUE))
 		return FALSE
+
+	if(istype(minion_or_type))
+		minion_or_type.wipe_old_beastmasters()
 
 	//does the mob exist? if not, spawn it. if its already spawned in, just reference them
 	var/mob/living/minion
@@ -103,6 +96,22 @@
 
 	if(!length(beastmaster_minions))
 		unregister_beastmaster_signals()
+
+/mob/living/carbon/human/proc/can_tame_beastmaster_minion(mob/living/living_minion, feedback)
+	if(istype(living_minion))
+		if(living_minion in beastmaster_minions)
+			if(feedback)
+				to_chat(src, span_warning("[living_minion] already heads your commands."))
+			return FALSE
+
+	//limit of (leadership) + 1
+	var/max_minions = st_get_stat(STAT_LEADERSHIP) + 1
+	if(length(beastmaster_minions) >= max_minions)
+		if(feedback)
+			to_chat(src, span_warning("You cannot control more than [max_minions] minion[max_minions > 1 ? "s" : ""]!"))
+		return FALSE
+
+	return TRUE
 
 /mob/proc/wipe_old_beastmasters()
 	SEND_SIGNAL(src, COMSIG_MOB_WIPE_BEASTMASTER)

--- a/modular_darkpack/modules/beastmaster/code/beastmaster_minion_management.dm
+++ b/modular_darkpack/modules/beastmaster/code/beastmaster_minion_management.dm
@@ -9,11 +9,12 @@
 )
 
 /mob/living/carbon/human/proc/add_beastmaster_minion(mob/living/minion_or_type, turf/spawn_location)
-	//first, make sure the beastmaster_minions list is accurate
-	for(var/mob/living/minion in beastmaster_minions)
-		if(QDELETED(minion) || minion.stat == DEAD)
-			beastmaster_minions -= minion
-			minion_command_components -= minion
+	if(istype(minion_or_type))
+		if(minion_or_type in beastmaster_minions)
+			to_chat(src, span_warning("[minion_or_type] already heads your commands."))
+			return FALSE
+		else
+			minion_or_type.wipe_old_beastmasters()
 
 	//limit of (leadership) + 1
 	var/max_minions = st_get_stat(STAT_LEADERSHIP) + 1
@@ -23,9 +24,9 @@
 
 	//does the mob exist? if not, spawn it. if its already spawned in, just reference them
 	var/mob/living/minion
-	if(ispath(minion_or_type, /mob/living))
+	if(ispath(minion_or_type))
 		minion = new minion_or_type(spawn_location || get_turf(src))
-	else if(isliving(minion_or_type))
+	else if(istype(minion_or_type))
 		minion = minion_or_type
 	else
 		return FALSE
@@ -63,7 +64,7 @@
 	//if we didnt have beastmaster minions before, then register beastmaster signals.
 	var/had_minions = length(beastmaster_minions)
 	beastmaster_minions += minion
-	RegisterSignal(minion, COMSIG_LIVING_DEATH, PROC_REF(on_minion_death))
+	RegisterSignals(minion, list(COMSIG_LIVING_DEATH, COMSIG_QDELETING, COMSIG_MOB_WIPE_BEASTMASTER), PROC_REF(on_wipe_beastmaster))
 
 	if(!had_minions)
 		register_beastmaster_signals()
@@ -72,14 +73,10 @@
 	return TRUE
 
 //when the minion dies we need to remove them from beastmaster_minions, and if there are no more minions, remove the signals from the master.
-/mob/living/carbon/human/proc/on_minion_death(mob/living/minion)
+/mob/living/carbon/human/proc/on_wipe_beastmaster(mob/living/minion)
 	SIGNAL_HANDLER
-	beastmaster_minions -= minion
-	minion_command_components -= minion
-	UnregisterSignal(minion, COMSIG_LIVING_DEATH)
 
-	if(!length(beastmaster_minions))
-		unregister_beastmaster_signals()
+	remove_beastmaster_minion(minion)
 
 /mob/living/carbon/human/proc/remove_beastmaster_minion(mob/living/minion)
 	if(!minion)
@@ -102,9 +99,12 @@
 	//remove them from the owner's minion's list and unregister signals if the list is now empty
 	beastmaster_minions -= minion
 	minion_command_components -= minion
-	UnregisterSignal(minion, COMSIG_LIVING_DEATH)
+	UnregisterSignal(minion, list(COMSIG_LIVING_DEATH, COMSIG_QDELETING, COMSIG_MOB_WIPE_BEASTMASTER))
 
 	if(!length(beastmaster_minions))
 		unregister_beastmaster_signals()
+
+/mob/proc/wipe_old_beastmasters()
+	SEND_SIGNAL(src, COMSIG_MOB_WIPE_BEASTMASTER)
 
 #undef BEASTMASTER_COMMANDS

--- a/modular_darkpack/modules/npc/code/nonhuman/beastmaster/necromancy_zombies.dm
+++ b/modular_darkpack/modules/npc/code/nonhuman/beastmaster/necromancy_zombies.dm
@@ -23,9 +23,6 @@
 /mob/living/basic/beastmaster/giovanni_zombie/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/ai_retaliate)
-	var/datum/component/obeys_commands/old = GetComponent(/datum/component/obeys_commands)
-	if(old)
-		qdel(old)
 
 /mob/living/basic/beastmaster/giovanni_zombie/level1 // Low health, low damage distraction unit
 	name = "drone"

--- a/modular_darkpack/modules/powers/code/discipline/animalism.dm
+++ b/modular_darkpack/modules/powers/code/discipline/animalism.dm
@@ -125,9 +125,6 @@
 /mob/living/basic/mouse/vampire/summoned/Initialize(mapload)
 	AddElement(/datum/element/ai_retaliate)
 	. = ..()
-	var/datum/component/obeys_commands/old = GetComponent(/datum/component/obeys_commands)
-	if(old)
-		qdel(old)
 
 /mob/living/basic/pet/cat/darkpack/summoned
 	name = "cat"
@@ -137,12 +134,6 @@
 	melee_damage_upper = 12
 	obj_damage = 15
 	bloodpool = 2
-
-/mob/living/basic/pet/cat/darkpack/summoned/Initialize(mapload)
-	. = ..()
-	var/datum/component/obeys_commands/old = GetComponent(/datum/component/obeys_commands)
-	if(old)
-		qdel(old)
 
 /mob/living/basic/pet/dog/wolf/summoned
 	name = "wolf"
@@ -162,12 +153,6 @@
 	random_wolf_color = FALSE
 	bloodpool = 2
 
-/mob/living/basic/pet/dog/wolf/summoned/Initialize(mapload)
-	. = ..()
-	var/datum/component/obeys_commands/old = GetComponent(/datum/component/obeys_commands)
-	if(old)
-		qdel(old)
-
 /mob/living/basic/bat/summoned
 	name = "bat"
 	desc = "A bat bound to its master's will."
@@ -178,9 +163,3 @@
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
 	bloodpool = 2
-
-/mob/living/basic/bat/summoned/Initialize(mapload)
-	. = ..()
-	var/datum/component/obeys_commands/old = GetComponent(/datum/component/obeys_commands)
-	if(old)
-		qdel(old)

--- a/modular_darkpack/modules/powers/code/discipline/animalism.dm
+++ b/modular_darkpack/modules/powers/code/discipline/animalism.dm
@@ -9,24 +9,6 @@
 	desc = "Animalism power description"
 	effect_sound = 'modular_darkpack/modules/werewolf_the_apocalypse/sounds/gifts/wolves.ogg'
 
-/datum/discipline_power/animalism/activate()
-	. = ..()
-
-	if(!ishuman(owner))
-		return
-
-	for(var/mob/living/minion in owner.beastmaster_minions)
-		if(QDELETED(minion) || minion.stat == DEAD)
-			owner.beastmaster_minions -= minion
-
-	var/max_minions = owner.st_get_stat(STAT_LEADERSHIP) + 1
-	if(length(owner.beastmaster_minions) >= max_minions)
-		var/mob/living/oldest = owner.beastmaster_minions[1]
-		if(oldest)
-			owner.remove_beastmaster_minion(oldest)
-			qdel(oldest)
-
-
 //SUMMON RAT
 /datum/discipline_power/animalism/summon_rat
 	name = "Summon Rat"

--- a/modular_darkpack/modules/ritual_thaumaturgy/rituals/gargoyle_transformation.dm
+++ b/modular_darkpack/modules/ritual_thaumaturgy/rituals/gargoyle_transformation.dm
@@ -163,6 +163,7 @@
 	if(!G || QDELETED(G))
 		return
 	if(!G.key || !G.client)
+		QDEL_NULL(G.ai_controller)
 		G.ai_controller = new /datum/ai_controller/basic_controller/beastmaster_summon(G)
 		if(activator)
 			activator.add_beastmaster_minion(G)

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/gifts/tribes/black_spiral_dancers.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/gifts/tribes/black_spiral_dancers.dm
@@ -23,9 +23,9 @@
 		return TRUE
 
 	if(istype(basic_target, /mob/living/basic/bane))
-		qdel(basic_target.GetComponent(/datum/component/obeys_commands))
-		human_owner?.add_beastmaster_minion(target)
+		QDEL_NULL(basic_target.ai_controller)
 		basic_target.ai_controller = new /datum/ai_controller/basic_controller/beastmaster_summon(basic_target)
+		human_owner?.add_beastmaster_minion(target)
 		return TRUE
 
 	// Just summon a random shitter.

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/gifts/tribes/black_spiral_dancers.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/gifts/tribes/black_spiral_dancers.dm
@@ -13,10 +13,12 @@
 	rage_cost = 1
 
 /datum/action/cooldown/power/gift/bane_protector/Activate(atom/target)
-	. = ..()
-
 	var/mob/living/carbon/human/human_owner = astype(owner)
 	var/mob/living/basic/basic_target = astype(target)
+	if(!(human_owner?.can_tame_beastmaster_minion(basic_target, TRUE)))
+		return FALSE
+
+	. = ..()
 
 	var/datum/storyteller_roll/gift/bane_protector/roll_datum = new()
 	if(roll_datum.st_roll(owner, target) != ROLL_SUCCESS)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -476,6 +476,7 @@
 #include "code\__DEFINES\~darkpack\vampire_clan.dm"
 #include "code\__DEFINES\~darkpack\walls.dm"
 #include "code\__DEFINES\~darkpack\xp_and_freebie.dm"
+#include "code\__DEFINES\~darkpack\dcs\beastmaster_signals.dm"
 #include "code\__DEFINES\~darkpack\dcs\bouncer_signals.dm"
 #include "code\__DEFINES\~darkpack\dcs\fire_signals.dm"
 #include "code\__DEFINES\~darkpack\dcs\gun_signals.dm"


### PR DESCRIPTION

## About The Pull Request
Cleans up the behavoir so that we should always properly clear them if they:
- Die
- Get deleted
- Get tamed by someone else

We also return early if we already have them tamed. Why bother redoing everything.
## Why It's Good For The Game
Behavior didn't support taming a minion targeted instead of passing in a type very well.
Fixes #1172
## Changelog
:cl:
refactor: refactors beastmaster to handle taming a existing mob rather then spawning a new one
code: deleting or killing a summon is handled much better
/:cl:
