### PR TITLE
Fixes AK Sawn

### DIFF
--- a/modular_darkpack/modules/weapons/code/guns.dm
+++ b/modular_darkpack/modules/weapons/code/guns.dm
@@ -490,6 +490,7 @@
 	mag_display = TRUE
 	fire_sound = 'modular_darkpack/modules/deprecated/sounds/ak.ogg'
 	masquerade_violating = TRUE
+	can_be_sawn_off	= TRUE
 	serial_type = "KA"
 	var/rof = 0.2 SECONDS //300 RPM
 


### PR DESCRIPTION

## About The Pull Request

AK was missing its 'can saw' variable on the AK. 

## Why It's Good For The Game

Oversight, was making it so the AK can't be sawn.

## Changelog
:cl:
fix: Fixes AK sawing oversight.
/:cl:
