### PR TITLE
Vampire artifact spawner should spawn vampire stuffs

### DIFF
--- a/modular_darkpack/modules/occult_artifacts/code/_artifact.dm
+++ b/modular_darkpack/modules/occult_artifacts/code/_artifact.dm
@@ -140,6 +140,7 @@
 
 /obj/effect/spawner/random/occult/artifact/vampire_only
 	name = "random vampire artifact"
+	loot = null
 	loot_subtype_path = /obj/item/occult_artifact/vampire
 
 


### PR DESCRIPTION

## About The Pull Request
Possible leakage from its parent type allowing it to spawn either of the types. not an issue for wolf one cause it already overrode this  var
## Changelog
:cl:
fix: Vampire artifact spawner should only spawn vampire artifacts
/:cl:
