### PR TITLE
Set changelogs to compile by cron once a day

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -2,7 +2,7 @@ name: Compile changelogs
 
 on:
   schedule:
-    - cron: "0 0 * * 1"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -2,7 +2,7 @@ name: Compile changelogs
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * *" # DARKPACK EDIT CHANGE
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION

## About The Pull Request
Reverts https://github.com/tgstation/tgstation/pull/95018 because second city has no tgs to regularly do that for.
## Changelog
:cl:
code: changelog is generated once a day instead of a week
/:cl:
