### PR TITLE
Fixes dementation 4

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/dementation.dm
+++ b/modular_darkpack/modules/powers/code/discipline/dementation.dm
@@ -374,7 +374,7 @@ frenzy or Rötschreck response is automatic.
 	owner.say(attack_text, spans = list("bold", "singing"))
 	var/list/potential_targets = list()
 	for(var/mob/living/carbon/human/hearer in (get_hearers_in_view(8, owner) - owner))
-		if(!HAS_TRAIT(hearer, TRAIT_DEAF) || hearer.stat > CONSCIOUS)
+		if(HAS_TRAIT(hearer, TRAIT_DEAF) || hearer.stat > CONSCIOUS)
 			continue
 		potential_targets += hearer
 	var/targets_affected = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically 4 was supposed to grab targets while ignoring everyone who was either unconscious or deaf, instead it was making your malkavian characters target only deaf conscious people, this makes the power affect non deaf people while ignoring deaf people.
<img width="1643" height="857" alt="image" src="https://github.com/user-attachments/assets/780450df-6f95-4b43-ab22-3fe14225f080" />

## Why It's Good For The Game

I believe the power only affecting deaf people isn't intended.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed dementation 4 working incorrectly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
