### PR TITLE
Klaive activation now respects artifact identification

### DIFF
--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/weapons/klaives.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/weapons/klaives.dm
@@ -37,6 +37,9 @@
 	fera_silver_damage(target, silver_damage, 1) // Copyed the other silver weapon. Not super accurate.
 
 /obj/item/occult_artifact/werewolf/klaive/attack_self(mob/user, modifiers)
+	if(!identified)
+		return ..()
+
 	var/datum/splat/werewolf/werewolf_splat = get_werewolf_splat(user)
 	if(owner && identified)
 		if(stirred_spirit)

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/weapons/klaives.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/weapons/klaives.dm
@@ -41,7 +41,7 @@
 		return ..()
 
 	var/datum/splat/werewolf/werewolf_splat = get_werewolf_splat(user)
-	if(owner && identified)
+	if(owner)
 		if(stirred_spirit)
 			to_chat(user, span_warning("[src]'s spirit is already awake!"))
 			return


### PR DESCRIPTION

## About The Pull Request

Custom activation logic ran before the normal occult artifact identification flow. So when the weapon was still unidentified, using it would  show the "dead piece of silver" message instead of letting the item be identified first. This pr makes it so activation only happens once properly identified.
<img width="667" height="485" alt="image" src="https://github.com/user-attachments/assets/b27f0251-22b8-41d0-a360-d0ebd258c0b2" />

## Why It's Good For The Game

Fixes likely unintended behavior

## Changelog
:cl:
fix: fixed klaives not working properly
/:cl:
