### PR TITLE
BSD sprite trait

### DIFF
--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/subsplats/tribes/garou.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/subsplats/tribes/garou.dm
@@ -116,12 +116,15 @@
 		// /datum/action/cooldown/power/gift/resist_pain, // DARKPACK TODO - (Selectable Gifts)
 		// /datum/action/cooldown/power/gift/sense_wyrm, // DARKPACK TODO - (Selectable Gifts)
 	)
-	// tribe_trait = TRAIT_WYRMTAINTED_SPRITE
 
 /datum/subsplat/werewolf/tribe/garou/blackspiraldancers/psychomania_effect(mob/living/target, mob/living/owner)
 	target.playsound_local(target, "modular_darkpack/modules/powers/sounds/daimonion_laughs/demonlaugh3.ogg", 50, FALSE)
 	target.visible_message(span_warning("[target] whines in animalistic fear"), span_cult("VISIONS OF BRIMSTONE AND FLAME FLASH BEFORE MY EYES"))
 	target.Paralyze(5 SECONDS)
+
+/datum/subsplat/werewolf/tribe/garou/blackspiraldancers/on_gain(mob/living/carbon/human/gaining_mob, datum/splat/gaining_splat, joining_round)
+	. = ..()
+	ADD_TRAIT(gaining_mob, TRAIT_WYRMTAINTED_SPRITE, INNATE_TRAIT)
 
 /datum/subsplat/werewolf/tribe/garou/ronin
 	name = TRIBE_RONIN


### PR DESCRIPTION

## About The Pull Request

Upstreams this https://github.com/The-Final-Nights/The-Final-Nights-Rebase/pull/286
<img width="140" height="157" alt="image" src="https://github.com/user-attachments/assets/2b2162ff-ee8c-43e9-b95f-61a29bab113b" />


## Why It's Good For The Game

Cool sprites are now in use

## Changelog
:cl:
fix: BSDs can now make use of their unique sprites
/:cl:
