### PR TITLE
red news

### DIFF
--- a/code/__DEFINES/~darkpack/jobs.dm
+++ b/code/__DEFINES/~darkpack/jobs.dm
@@ -15,6 +15,7 @@
 #define JOB_ORDINARY_CITIZEN "Unassigned"
 #define JOB_STREET_JANITOR "Street Janitor"
 #define JOB_TAXI_DRIVER "Taxi Driver"
+#define JOB_RED_NEWS_REPORTER "Red News Reporter"
 
 //Camarilla
 #define JOB_PRINCE "Prince"
@@ -108,6 +109,7 @@
 //////////////////////////////////////////////////
 
 #define JOB_DISPLAY_ORDER_CITIZEN 1
+#define JOB_DISPLAY_ORDER_RED_NEWS_REPORTER 2
 
 #define JOB_DISPLAY_ORDER_PRINCE 1
 #define JOB_DISPLAY_ORDER_CLERK 2

--- a/modular_darkpack/master_files/code/game/objects/items/devices/broadcast_camera.dm
+++ b/modular_darkpack/master_files/code/game/objects/items/devices/broadcast_camera.dm
@@ -1,0 +1,2 @@
+/obj/item/broadcast_camera
+	broadcast_name = "RED News"

--- a/modular_darkpack/modules/jobs/code/miscelllaneous/red_news.dm
+++ b/modular_darkpack/modules/jobs/code/miscelllaneous/red_news.dm
@@ -1,0 +1,32 @@
+/datum/job/vampire/red_news_reporter
+	title = JOB_RED_NEWS_REPORTER
+	description = "You are a reporter for the Pentex holding company owned brand RED news. You are responsible for reporting on the events of the city and keeping the public informed - or, as RED news also hosts many info-tainment broadcasts, host your own entertainment show. Either way, you have your own timeslot, better make the most of it!"
+	faction = FACTION_CITY
+	total_positions = 2
+	spawn_positions = 2
+	outfit = /datum/outfit/job/vampire/red_news_reporter
+	exp_granted_type = EXP_TYPE_SPIRAL
+	config_tag = "RED_NEWS_REPORTER"
+	display_order = JOB_DISPLAY_ORDER_RED_NEWS_REPORTER
+	departments_list = list(
+		/datum/job_department/citizen
+	)
+	job_flags = CITY_JOB_FLAGS
+	minimum_masquerade = 0
+	alt_titles = list(
+		"Red News Cameraman",
+		"Red News Talking Head",
+		"Red News Infomercial Salesperson",
+		"Red News Entertainment Host",
+		"Red News Late Night Talkshow Host"
+	)
+	disallowed_clans = list(VAMPIRE_CLAN_CAPPADOCIAN, VAMPIRE_CLAN_SAMEDI, VAMPIRE_CLAN_GARGOYLE, VAMPIRE_CLAN_KIASYD, VAMPIRE_CLAN_NOSFERATU)
+
+
+/datum/outfit/job/vampire/red_news_reporter
+	name = JOB_RED_NEWS_REPORTER
+	jobtype = /datum/job/vampire/red_news_reporter
+	l_pocket = /obj/item/smartphone
+	backpack_contents = list(/obj/item/card/credit)
+	uniform = /obj/item/clothing/under/vampire/suit
+	l_hand = /obj/item/broadcast_camera

--- a/modular_darkpack/modules/jobs/code/miscelllaneous/red_news.dm
+++ b/modular_darkpack/modules/jobs/code/miscelllaneous/red_news.dm
@@ -1,7 +1,7 @@
 /datum/job/vampire/red_news_reporter
 	title = JOB_RED_NEWS_REPORTER
 	description = "You are a reporter for the Pentex holding company owned brand RED news. You are responsible for reporting on the events of the city and keeping the public informed - or, as RED news also hosts many info-tainment broadcasts, host your own entertainment show. Either way, you have your own timeslot, better make the most of it!"
-	faction = FACTION_CITY
+	faction = FACTION_PENTEX
 	total_positions = 2
 	spawn_positions = 2
 	outfit = /datum/outfit/job/vampire/red_news_reporter

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7484,6 +7484,7 @@
 #include "modular_darkpack\modules\jobs\code\miscelllaneous\club_worker.dm"
 #include "modular_darkpack\modules\jobs\code\miscelllaneous\janitor.dm"
 #include "modular_darkpack\modules\jobs\code\miscelllaneous\priest.dm"
+#include "modular_darkpack\modules\jobs\code\miscelllaneous\red_news.dm"
 #include "modular_darkpack\modules\jobs\code\miscelllaneous\taxi.dm"
 #include "modular_darkpack\modules\jobs\code\pentex\affairs.dm"
 #include "modular_darkpack\modules\jobs\code\pentex\branch_lead.dm"


### PR DESCRIPTION
## About The Pull Request

RED news reporter

original pr by bomby

## Why It's Good For The Game

use in conjunction with mapped entertainment modules or evac status displays and greenscreens and captain caster objects for live feeds to all the citizens

## Changelog

:cl:
add: Adds the red news reporter role which can broadcast to the city using the captain-caster camera and mapped-in greenscreens as well as 'entertainment monitors' and the mobile cameras

/:cl:
