### PR TITLE
Fixing random runtimes

### DIFF
--- a/modular_darkpack/modules/drugs/code/weed/tray.dm
+++ b/modular_darkpack/modules/drugs/code/weed/tray.dm
@@ -20,7 +20,7 @@
 	return NONE
 
 /obj/machinery/hydroponics/simple/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(default_deconstruction_crowbar(tool, TRUE))
+	if(default_deconstruction_crowbar(user, tool))
 		return
 
 	return ..()

--- a/modular_darkpack/modules/powers/code/discipline/auspex/aura_component.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/aura_component.dm
@@ -185,14 +185,10 @@
 		aura_smoke = new /obj/effect/abstract/shared_particle_holder(null, /particles/smoke/aura)
 		aura_smoke.blend_mode = 2
 		aura_smoke.add_filter("particle_blur", 1, gauss_blur_filter(8))
-	var/mutable_appearance/aura_appearance = mutable_appearance('modular_darkpack/modules/powers/icons/auras.dmi', "aura", ABOVE_MOB_LAYER, parent_mob, ABOVE_GAME_PLANE)
-	// high humanity kindred OR kindred with blush of health avoid getting the still heart. in auspex, their hearts will instead show like humans; beating!
-	if(get_kindred_splat(parent_mob))
-		var/mob/living/carbon/human/lick = parent_mob
-		var/datum/st_stat/morality_path/morality/stat_morality = lick?.storyteller_stats[STAT_MORALITY]
-		if((stat_morality?.morality_path?.alignment != MORALITY_HUMANITY || stat_morality?.get_score() < 5) && !HAS_TRAIT(parent_mob, TRAIT_BLUSH_OF_HEALTH))
-			aura_appearance = mutable_appearance('modular_darkpack/modules/powers/icons/auras.dmi', "aura_dead", ABOVE_MOB_LAYER, parent_mob, ABOVE_GAME_PLANE)
-	if(parent_mob.stat == DEAD)
+	var/mutable_appearance/aura_appearance
+	if(parent_mob.heart_is_beating())
+		aura_appearance = mutable_appearance('modular_darkpack/modules/powers/icons/auras.dmi', "aura", ABOVE_MOB_LAYER, parent_mob, ABOVE_GAME_PLANE)
+	else
 		aura_appearance = mutable_appearance('modular_darkpack/modules/powers/icons/auras.dmi', "aura_dead", ABOVE_MOB_LAYER, parent_mob, ABOVE_GAME_PLANE)
 	update_aura_colors(aura_appearance, holder)
 	update_aura_overlays(aura_appearance, holder)
@@ -344,3 +340,26 @@
 /datum/component/aura/proc/has_pale_blotches(mob/parent_mob)
 	if(!HAS_TRAIT(parent_mob, TRAIT_PALE_AURA) && get_ghoul_splat(parent_mob))
 		return TRUE
+
+
+/mob/proc/heart_is_beating()
+	return FALSE
+
+/mob/living/heart_is_beating()
+	if(stat == DEAD)
+		return FALSE
+
+	return TRUE
+
+/mob/living/carbon/human/heart_is_beating()
+	var/obj/item/organ/heart/beating_heart = get_organ_slot(ORGAN_SLOT_HEART)
+	if(!istype(beating_heart) || !(beating_heart.is_beating()))
+		return FALSE
+
+	// high humanity kindred OR kindred with blush of health avoid getting the still heart. in auspex, their hearts will instead show like humans; beating!
+	if(get_kindred_splat(src))
+		var/datum/st_stat/morality_path/morality/stat_morality = storyteller_stats[STAT_MORALITY]
+		if((stat_morality?.morality_path?.alignment != MORALITY_HUMANITY || stat_morality?.get_score() < 5) && !HAS_TRAIT(src, TRAIT_BLUSH_OF_HEALTH))
+			return FALSE
+
+	return TRUE

--- a/modular_darkpack/modules/powers/code/discipline/auspex/heartbeat_sensing_component.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/heartbeat_sensing_component.dm
@@ -58,8 +58,7 @@
 	if(isnull(receivers[parent_mob]))
 		receivers[parent_mob] = list()
 	for(var/mob/living/carbon/living_carbon in orange(parent_mob.client?.view, get_turf(parent_mob)))
-		var/obj/item/organ/heart/beating_heart = living_carbon.get_organ_slot(ORGAN_SLOT_HEART)
-		if(!istype(beating_heart) && !(beating_heart.is_beating()))
+		if(!living_carbon.heart_is_beating())
 			continue
 		show_heartbeat_image(living_carbon)
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/examine_text.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/examine_text.dm
@@ -8,6 +8,8 @@
 		var/same_tribe = FALSE
 		var/is_known = FALSE
 
+		if(!tribe)
+			return
 		if(!wolp_splat.tribe || !wolp_splat.auspice)
 			return
 		if(tribe.name == wolp_splat.tribe.name)

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/totems.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/totems.dm
@@ -147,7 +147,7 @@
 			return
 		var/obj/umbra_portal/prev = locate() in get_step(src, SOUTH)
 		if(!prev)
-			if(shifter_splat.auspice.name == AUSPICE_THEURGE)
+			if(shifter_splat.auspice?.name == AUSPICE_THEURGE)
 				if(!opening)
 					opening = TRUE
 					if(do_after(user, 10 SECONDS, src))
@@ -156,7 +156,7 @@
 			else
 				to_chat(user, span_warning("You need a Theurge to open the Moon Gates!"))
 		else
-			if(shifter_splat.auspice.name == AUSPICE_THEURGE)
+			if(shifter_splat.auspice?.name == AUSPICE_THEURGE)
 				collapse_portal(prev)
 
 /obj/structure/werewolf_totem/proc/spawn_portal()


### PR DESCRIPTION

## About The Pull Request
Runtime from not having an auspice, Prob corax.
<img width="1238" height="262" alt="image" src="https://github.com/user-attachments/assets/49fdee93-13b9-4dae-a94f-c03b59acf265" />

Runtime from trying to check the beating of a heart for a a heart that doesnt exist.

Kinfolk dont have a tribe so runtime trying to compare tribes. 
<img width="1127" height="410" alt="image" src="https://github.com/user-attachments/assets/5e61da48-55aa-4cbc-a892-54b4b4863857" />

Bad arg order on planter.
<img width="1348" height="252" alt="image" src="https://github.com/user-attachments/assets/87203bbd-8f9d-46f0-aba7-5d561aa141fa" />
## Why It's Good For The Game
Runtimes bad.
## Changelog
:cl:
fix: Improves handling for detecting a heartbeat to be more consistent
code: Fixes random runtimes
/:cl:
