### PR TITLE
Dropdown for character slots in preferences

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/index.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/index.tsx
@@ -35,7 +35,7 @@ function CharacterProfiles(props: ProfileProps) {
   const { activeSlot, onClick, profiles } = props;
 
   // DARKPACK EDIT CHANGE START
-  if (profiles.length > 5)
+  if (profiles.length <= 5)
     // TG Version
     return (
       <Stack justify="center" wrap>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/index.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useBackend } from 'tgui/backend';
-import { Button, Stack } from 'tgui-core/components';
+import { Button, Dropdown, Flex, Stack } from 'tgui-core/components'; // DARKPACK EDIT CHANGE
 import { exhaustiveCheck } from 'tgui-core/exhaustive';
 
 import { PageButton } from '../components/PageButton';
@@ -34,23 +34,47 @@ type ProfileProps = {
 function CharacterProfiles(props: ProfileProps) {
   const { activeSlot, onClick, profiles } = props;
 
-  return (
-    <Stack justify="center" wrap>
-      {profiles.map((profile, slot) => (
-        <Stack.Item key={slot} mb={1}>
-          <Button
-            selected={slot === activeSlot}
-            onClick={() => {
+  // DARKPACK EDIT CHANGE START
+  if (profiles.length > 5)
+    // TG Version
+    return (
+      <Stack justify="center" wrap>
+        {profiles.map((profile, slot) => (
+          <Stack.Item key={slot} mb={1}>
+            <Button
+              selected={slot === activeSlot}
+              onClick={() => {
+                onClick(slot);
+              }}
+              fluid
+            >
+              {profile ?? 'New Character'}
+            </Button>
+          </Stack.Item>
+        ))}
+      </Stack>
+    );
+  else
+    // Expanded version if we have way 2 many slots.
+    return (
+      <Flex align="center" justify="center">
+        <Flex.Item width="25%">
+          <Dropdown
+            width="100%"
+            selected={activeSlot as unknown as string}
+            displayText={profiles[activeSlot]}
+            options={profiles.map((profile, slot) => ({
+              value: slot,
+              displayText: profile ?? 'New Character',
+            }))}
+            onSelected={(slot) => {
               onClick(slot);
             }}
-            fluid
-          >
-            {profile ?? 'New Character'}
-          </Button>
-        </Stack.Item>
-      ))}
-    </Stack>
-  );
+          />
+        </Flex.Item>
+      </Flex>
+    );
+  // DARKPACK EDIT CHANGE END
 }
 
 export function CharacterPreferenceWindow(props) {
@@ -134,7 +158,7 @@ export function CharacterPreferenceWindow(props) {
           </Stack.Item>
 
           {
-          // DARKPACK EDIT ADD START - stats / disciplines
+            // DARKPACK EDIT ADD START - stats / disciplines
           }
           <Stack.Item grow>
             <PageButton
@@ -159,7 +183,7 @@ export function CharacterPreferenceWindow(props) {
             </Stack.Item>
           )}
           {
-          // DARKPACK EDIT END
+            // DARKPACK EDIT END
           }
 
           <Stack.Item grow>
@@ -186,8 +210,7 @@ export function CharacterPreferenceWindow(props) {
             </PageButton>
           </Stack.Item>
 
-          {
-            /* DARKPACK EDIT REMOVAL - (We dont have antags and this is useless atm)
+          {/* DARKPACK EDIT REMOVAL - (We dont have antags and this is useless atm)
           <Stack.Item grow>
             <PageButton
               currentPage={currentPage}
@@ -197,11 +220,10 @@ export function CharacterPreferenceWindow(props) {
               Antagonists
             </PageButton>
           </Stack.Item>
-            */
-          }
+            */}
 
           {
-          // DARKPACK EDIT ADD START - Merits
+            // DARKPACK EDIT ADD START - Merits
           }
           <Stack.Item grow>
             <PageButton
@@ -213,7 +235,7 @@ export function CharacterPreferenceWindow(props) {
             </PageButton>
           </Stack.Item>
           {
-          // DARKPACK EDIT ADD END
+            // DARKPACK EDIT ADD END
           }
         </Stack>
       </Stack.Item>


### PR DESCRIPTION

## About The Pull Request
Modified version of part of https://github.com/NocturneWoD/NocturneWoD-SecondCity/pull/17 which i think is just from another hrp server but it doesnt say where and i've definitly seen it in like 5 other places.
## Why It's Good For The Game
A billion buttons looks bad.
## Changelog
:cl:
qol: If you have more then 5 character profiles in preferences, it displays as a dropdown instead.
/:cl:
