### PR TITLE
Acid and blood can be scooped from the respective tiles

### DIFF
--- a/modular_darkpack/modules/walls/code/floors/water.dm
+++ b/modular_darkpack/modules/walls/code/floors/water.dm
@@ -27,6 +27,7 @@
 	light_range = 1
 	light_power = 0.5
 	baseturfs = /turf/open/water/acid
+	reagent_to_extract = /datum/reagent/toxin/acid
 
 /turf/open/water/acid/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
@@ -62,6 +63,8 @@
 	baseturfs = /turf/open/water/bloodwave
 	immerse_overlay = "immerse_deep"
 	is_swimming_tile = TRUE
+	// Maybe this should be mixed in with a contiminant.
+	reagent_to_extract = /datum/reagent/blood
 	///All dirs we can expand to
 	var/list/available_dirs = list(NORTH,SOUTH,EAST,WEST,DOWN)
 	///Cooldown on the expansion process


### PR DESCRIPTION

## About The Pull Request
scoop my goop
## Why It's Good For The Game
That shit is not water.
Having an infinite source of blood is probs weird but i would need to rework the reagent code to be a list of percent extracted and i cant be asked.
## Changelog
:cl:
fix: Non-water turfs now have the correct scoop-able material
/:cl:
