### PR TITLE
Hunger tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/physiology.dm
+++ b/code/modules/mob/living/carbon/human/physiology.dm
@@ -41,7 +41,7 @@
 
 	var/datum/armor/armor // internal armor datum
 
-	var/hunger_mod = 0.2 //% of hunger rate taken per tick. // DARKPACK EDIT CHANGE - ORIGINAL: var/hunger_mod = 1
+	var/hunger_mod = 1 //% of hunger rate taken per tick.
 
 /datum/physiology/New()
 	armor = new

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -1,6 +1,6 @@
 /datum/movespeed_modifier/obesity
 	// large weight slows even if flying and floating
-	multiplicative_slowdown = 1.5
+	multiplicative_slowdown = 1.2 //DARKPACK EDIT CHANGE - Original : multiplicative_slowdown = 1.2
 
 /datum/movespeed_modifier/monkey_reagent_speedmod
 	variable = TRUE

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -1,6 +1,6 @@
 /datum/movespeed_modifier/obesity
 	// large weight slows even if flying and floating
-	multiplicative_slowdown = 1.2 //DARKPACK EDIT CHANGE - Original : multiplicative_slowdown = 1.2
+	multiplicative_slowdown = 1.2 // DARKPACK EDIT CHANGE - ORIGINAL: multiplicative_slowdown = 1.2
 
 /datum/movespeed_modifier/monkey_reagent_speedmod
 	variable = TRUE

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -1,6 +1,6 @@
 /datum/movespeed_modifier/obesity
 	// large weight slows even if flying and floating
-	multiplicative_slowdown = 1.2 // DARKPACK EDIT CHANGE - ORIGINAL: multiplicative_slowdown = 1.2
+	multiplicative_slowdown = 1.5
 
 /datum/movespeed_modifier/monkey_reagent_speedmod
 	variable = TRUE

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -37,7 +37,7 @@
 	var/metabolism_efficiency = 0.05 // the lowest we should go is 0.025
 
 	/// Multiplier for hunger rate
-	var/hunger_modifier = 0.2 // DARKPACK EDIT CHANGE - ORIGINAL: var/hunger_modifier = 1
+	var/hunger_modifier = 1
 	/// Whether the stomach's been repaired with surgery and can be fixed again or not
 	var/operated = FALSE
 	/// List of all atoms within the stomach
@@ -203,7 +203,7 @@
 /obj/item/organ/stomach/proc/handle_hunger_slowdown(mob/living/carbon/human/human)
 	var/hungry = (500 - human.nutrition) / 5 //So overeat would be 100 and default level would be 80
 	if(hungry >= 70)
-		human.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/hunger, multiplicative_slowdown = (hungry / 80)) // DARKPACK EDIT CHANGE - ORIGINAL: human.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/hunger, multiplicative_slowdown = (hungry / 50))
+		human.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/hunger, multiplicative_slowdown = (hungry / 50))
 	else
 		human.remove_movespeed_modifier(/datum/movespeed_modifier/hunger)
 

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -169,6 +169,7 @@
 			hunger_rate = 3 * HUNGER_FACTOR
 		hunger_rate *= hunger_modifier
 		hunger_rate *= human.physiology.hunger_mod
+		hunger_rate *= CONFIG_GET(number/hunger_modifier) // DARKPACK EDIT ADD
 		human.adjust_nutrition(-hunger_rate * seconds_per_tick)
 
 	var/nutrition = human.nutrition

--- a/config/darkpack_config.txt
+++ b/config/darkpack_config.txt
@@ -72,6 +72,8 @@ SWING_COMBAT
 #PASSIVE_BP_DRAIN
 PASSIVE_BP_DRAIN_TIMER 12000
 
+#HUNGER_MODIFIER 0.5
+
 ## Configs for which Discipline keybinds are enabled (unbound by default) and how they behave
 ## Default keybinds where you select a Discipline then activate a power
 DISCIPLINE_KEYBINDS

--- a/modular_darkpack/master_files/code/controllers/configuration/entries/game_options.dm
+++ b/modular_darkpack/master_files/code/controllers/configuration/entries/game_options.dm
@@ -9,3 +9,6 @@
 	default = 5
 	min_val = 5
 	max_val = 50
+
+/datum/config_entry/number/hunger_modifier
+	default = 0.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves hunger multipliers from https://github.com/DarkPack13/SecondCity/pull/857 to a config rather then being in two seperate places which made it so our code has a * 0.04 of normal tg which is why no one got hungry.
Default config value is set to 0.5 of normal TG values. This is something that should likely be tweaked.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
hunger rate is pretty subjective and depends on the length of the round and population imo. 

Having a ton of stores/food/cooking but NO reason to ever eat is bad. I might follow this up with a minor buff for eating player made food.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Hunger is no longer accidentally soft-removed
config: Hunger rate is on a config for easier tweaking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
