### PR TITLE
Guestbook code tweaks

### DIFF
--- a/code/__DEFINES/~darkpack/guestbook.dm
+++ b/code/__DEFINES/~darkpack/guestbook.dm
@@ -8,4 +8,7 @@
 /// We will not be known by others, even if they pass checks in any way otherwise
 #define GUESTBOOK_FORGETMENOT (1 << 3)
 
-#define GET_GUESTBOOK_NAME(mob, guest) (mob?.mind?.guestbook?.get_known_name(mob, guest) ? mob?.mind?.guestbook?.get_known_name(mob, guest) : guest.name)
+/// Differs from GET_GUESTBOOK_NAME_TRUE as it returns the known name OR the whole mob for situations where we directly embed into a string for text macros.
+#define GET_GUESTBOOK_NAME(mob, guest) (mob?.mind?.guestbook?.get_known_name(mob, guest) || guest)
+/// Macro to get a STRING (never a mob) of the name we refer to them as.
+#define GET_GUESTBOOK_NAME_TRUE(mob, guest) (mob?.mind?.guestbook?.get_known_name(mob, guest) || guest.name)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -176,7 +176,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	//Speaker name
 	var/namepart = message_mods[MODE_SPEAKER_NAME_OVERRIDE] || speaker.get_message_voice(visible_name)
 
-	// DARKPACK EDIT START
+	// DARKPACK EDIT ADD START - GUESTBOOK
 	var/atom/movable/reliable_narrator = speaker
 	if(istype(reliable_narrator, /atom/movable/virtualspeaker))
 		var/atom/movable/virtualspeaker/fakespeaker = reliable_narrator
@@ -191,11 +191,12 @@ GLOBAL_LIST_INIT(freqtospan, list(
 			else
 				var/mob/living/living_narrator = reliable_narrator
 				namepart = "[living_narrator.get_generic_name(prefixed = TRUE, lowercase = TRUE)]"
-
+	// DARKPACK EDIT ADD END
+	// DARKPACK EDIT ADD START - PHONES
 	if(text2num(radio_freq) >= USABLE_RADIO_FREQUENCY_FOR_PHONE_RANGE)
 		var/icon/phone_icon = icon('modular_darkpack/modules/phones/icons/chat_icon.dmi', "phone")
 		freqpart = icon2html(phone_icon, src)
-	// DARKPACK EDIT END
+	// DARKPACK EDIT ADD END
 
 	//End name span.
 	var/endspanpart = "</span>"

--- a/modular_darkpack/modules/guestbook/code/guestbook.dm
+++ b/modular_darkpack/modules/guestbook/code/guestbook.dm
@@ -136,7 +136,8 @@
 	if(guest)
 		if(user == guest)
 			return guest.real_name
-		if(!guest.client?.prefs.read_preference(/datum/preference/toggle/show_identity_when_masked) && guest.get_face_name() == "Unknown")
+		var/mob/living/carbon/carbon_guest = astype(guest)
+		if((carbon_guest?.get_face_name() == "Unknown") && !carbon_guest.client?.prefs.read_preference(/datum/preference/toggle/show_identity_when_masked))
 			return null
 		checked_name = guest.real_name
 	return LAZYACCESS(known_names, checked_name)

--- a/modular_darkpack/modules/npc/code/nonhuman/friendly/dog.dm
+++ b/modular_darkpack/modules/npc/code/nonhuman/friendly/dog.dm
@@ -1,6 +1,5 @@
 /mob/living/basic/pet/dog/darkpack
 	name = "dog"
-	real_name = "dog"
 	icon_state = "dog1"
 	desc = "That's an ouppy."
 	base_icon_state = "dog"

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/basic_mobs/wolf.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/basic_mobs/wolf.dm
@@ -36,7 +36,6 @@
 
 /mob/living/basic/pet/dog/wolf
 	name = "wolf"
-	real_name = "wolf"
 	icon_state = "wolf1"
 	desc = "That's a big, scary wolf. Might be best to steer clear."
 	base_icon_state = "wolf"
@@ -148,12 +147,12 @@
 
 // WOLF TYPES
 /mob/living/basic/pet/dog/wolf/kinfolk
-	real_name = "kinfolk"
+	// real_name = "kinfolk"
 	wolf_type = TYPE_KINFOLK
 
 /mob/living/basic/pet/dog/wolf/kinfolk/spiral
 	name = "rotten wolf"
-	real_name = "tainted kinfolk"
+	// real_name = "tainted kinfolk"
 	icon_state = "wolfspiral1"
 	base_icon_state = "wolfspiral"
 


### PR DESCRIPTION

## About The Pull Request
Breaks the guestbook code up slightly and rewrites the code so that the primarly used define returns the MOB instead of the name.
This means that in all scenarios where we directly imbued into a string (all of current uses), text macros work as intented https://ref.dm-lang.org/DM/text/macros/
I didnt check if this fixes anything persay but it likely affects situations for everything that is not a human (as they use macros alot more often)


Also fixes 
<img width="1179" height="79" alt="image" src="https://github.com/user-attachments/assets/23501f8b-7c9d-4b86-8028-fa65ff9732fa" />
I discovered caused by a recent pr while leaving my game open (the dog i was testing barked)

I orginnaly assumed this was what caused #1130 but that was acctually its own issue but i fixed it.
## Why It's Good For The Game
Grammer good.
Bugs bad.
Fixes #1130
## Changelog
:cl:
fix: Guestbook should handle text macros better
fix: Dogs are treated as an improper noun
/:cl:
