### PR TITLE
Highest ranking wolfs can adjust renown of lower ranks

### DIFF
--- a/code/__DEFINES/~darkpack/fera/werewolf_renown.dm
+++ b/code/__DEFINES/~darkpack/fera/werewolf_renown.dm
@@ -11,3 +11,5 @@
 #define RANK_ATHRO 4
 #define RANK_ELDER 5
 #define RANK_LEGEND 6
+
+#define MAX_RENOWN 10

--- a/modular_darkpack/modules/jobs/code/garou/councillor.dm
+++ b/modular_darkpack/modules/jobs/code/garou/councillor.dm
@@ -31,6 +31,11 @@
 		"Guardian"
 	)
 
+/datum/job/vampire/councillor/after_spawn(mob/living/spawned, client/player_client)
+	. = ..()
+	var/datum/action/ability = new /datum/action/cooldown/modify_renown(spawned)
+	ability.Grant(spawned)
+
 /datum/outfit/job/vampire/councillor
 	name = "Sept Councillor"
 	jobtype = /obj/item/card/park_ranger/oversight

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/renown.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/renown.dm
@@ -1,9 +1,6 @@
-#define MAX_RENOWN 10
-
 /datum/splat/werewolf/proc/adjust_renown(attribute, amount)
 	if(!renown[attribute])
 		renown[attribute] = 0
-
 
 	var/old_rank = renown_rank
 	var/new_amount = clamp(renown[attribute] + amount, 0, MAX_RENOWN)
@@ -146,5 +143,3 @@
 	message_admins("[ADMIN_LOOKUPFLW(owner)] adjusted [renown_input] of [ADMIN_LOOKUPFLW(target)] by [renown_amount] for reason: \"[renown_reason]\".")
 	owner.log_message(" adjusted [renown_input] of [key_name(target)] by [renown_amount] for reason: \"[renown_reason]\".", LOG_GAME)
 	return TRUE
-
-#undef MAX_RENOWN

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/renown.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/renown.dm
@@ -99,4 +99,52 @@
 				if(RANK_LEGEND)
 					return "legend"
 
+/datum/action/cooldown/modify_renown
+	name = "Award/Remove Renown"
+	button_icon = 'modular_darkpack/modules/werewolf_the_apocalypse/icons/werewolf_abilities.dmi'
+	button_icon_state = "wip"
+	click_to_activate = TRUE
+
+/datum/action/cooldown/modify_renown/Activate(atom/target)
+	if(target == owner)
+		return
+	var/mob/living/living_target = astype(target)
+	if(!living_target)
+		return
+
+	. = ..()
+
+	var/datum/splat/werewolf/werewolf_spalt = get_werewolf_splat(living_target)
+	if(!werewolf_spalt)
+		return TRUE
+
+	var/datum/splat/werewolf/our_werewolf_spalt = get_werewolf_splat(owner)
+	if(!our_werewolf_spalt)
+		return TRUE
+
+	if(werewolf_spalt.renown_rank >= our_werewolf_spalt.renown_rank)
+		to_chat(owner, span_warning("They have a rank equal or greater then yours."))
+		return TRUE
+
+	to_chat(owner, span_warning("This adjusts the renown permently of the selected mob. This is logged to admins and should be used with care."))
+
+	var/renown_input = tgui_alert(owner, "Choose Renown to adjust.", "Modify Renown", ALL_RENOWNS)
+	if(!renown_input)
+		return TRUE
+
+	var/renown_amount = tgui_input_number(owner, "Choose amount to adjust.", "Modify Renown", 1, MAX_RENOWN, -MAX_RENOWN)
+	if(!renown_amount)
+		return TRUE
+
+	var/renown_reason = tgui_input_text(owner, "Declare a reason for this shift. A table for sample renown awards can be found in Werewolf The Apocalypse 20th Anniversary Edition p. 246", "Modify Renown")
+	if(!renown_reason)
+		return TRUE
+
+	werewolf_spalt.adjust_renown(renown_input, renown_amount)
+	to_chat(owner, span_notice("[renown_input] adjusted!"))
+
+	message_admins("[ADMIN_LOOKUPFLW(owner)] adjusted [renown_input] of [ADMIN_LOOKUPFLW(target)] by [renown_amount] for reason: \"[renown_reason]\".")
+	owner.log_message(" adjusted [renown_input] of [key_name(target)] by [renown_amount] for reason: \"[renown_reason]\".", LOG_GAME)
+	return TRUE
+
 #undef MAX_RENOWN


### PR DESCRIPTION

## About The Pull Request
Adds a mechanic to adjust renown that is not ahelping.

Adds an action for high ranking wolfs (councillor right now as im unsure how i would do this for bsd rn.) to be able to adjust any of the 3 values of any werewolf or kinfolk (since its technicly something they have in code).  This is logged and they have to provide a reason so administrative issues should not be too bad.

I foresee a similar addition for masquerade as I think it suffers from alot the same issues for how automatic is handled

In future I might add a config for this where you can opt into a automatic system more close to the masq where its all automatic. (and vice versa for the masq) I'm really not sold the best approach and i think it varies a bit based on servers.
Its not TOO different from the fact that a player can report your massq breach however.
## Why It's Good For The Game
Renown fufills a similar niche as masq were its a mutable value that is primarily a role-play mechanic which shifts across rounds and while persistent across rounds is still a temporary thing that you can loose or gain quite easily. 
It (and dignitas) are both functionally reputation meters whos realistic dishes are all currently fulfilled by player characters.
## Changelog
:cl:
add: Leaders of the Garou Nation can change the renown of other wolves.
/:cl:
