### PR TITLE
fix discipline/power harddels

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/__discipline.dm
+++ b/modular_darkpack/modules/powers/code/discipline/__discipline.dm
@@ -66,25 +66,25 @@
  * adding and removing powers.
  *
  * Arguments:
- * * level - the level to set the Discipline as, powers included
+ * * new_level - the level to set the Discipline as, powers included
  */
-/datum/discipline/proc/set_level(level)
-	level = clamp(level, 0, length(all_powers))
-	if (level == src.level)
+/datum/discipline/proc/set_level(new_level)
+	new_level = clamp(new_level, 0, length(all_powers))
+	if (new_level == level)
 		return
 
-	for (var/i in length(known_powers) + 1 to level)
+	for (var/i in length(known_powers) + 1 to new_level)
 		var/adding_power_type = all_powers[i]
 		var/datum/discipline_power/new_power = new adding_power_type(src)
 		known_powers += new_power
 		new_power.post_gain()
 
-	if (length(known_powers) > level)
-		var/list/datum/discipline_power/leftover_powers = known_powers.Copy(level + 1)
-		known_powers.Cut(level + 1)
+	if (length(known_powers) > new_level)
+		var/list/datum/discipline_power/leftover_powers = known_powers.Copy(new_level + 1)
+		known_powers.Cut(new_level + 1)
 		QDEL_LIST(leftover_powers)
 
-	src.level = level
+	level = new_level
 	update_current_power()
 
 /datum/discipline/proc/update_current_power()

--- a/modular_darkpack/modules/powers/code/discipline/__discipline.dm
+++ b/modular_darkpack/modules/powers/code/discipline/__discipline.dm
@@ -46,15 +46,14 @@
 	var/amount = level // how many levels are we giving them
 	if(level > length(all_powers)) // the amount of disc levels we are trying to give is greater than the amount of subtypes that exist for it
 		amount = length(all_powers) // so only give what exists
-	for (var/i in 1 to amount)
+	for(var/i in 1 to amount)
 		var/type_to_create = all_powers[i]
-		var/datum/discipline_power/new_power = new type_to_create(src)
-		known_powers += new_power
+		known_powers += new type_to_create(src)
 	current_power = known_powers[1]
 
 /datum/discipline/Destroy(force)
 	action_type = null
-	QDEL_NULL(current_power)
+	current_power = null
 	QDEL_LIST(known_powers)
 	all_powers = null
 	owner = null
@@ -70,26 +69,27 @@
  * * level - the level to set the Discipline as, powers included
  */
 /datum/discipline/proc/set_level(level)
+	level = clamp(level, 0, length(all_powers))
 	if (level == src.level)
 		return
 
-	var/list/datum/discipline_power/new_known_powers = list()
-	for (var/i in 1 to level)
-		if (length(known_powers) >= level)
-			new_known_powers.Add(known_powers[i])
-		else
-			var/adding_power_type = all_powers[i]
-			var/datum/discipline_power/new_power = new adding_power_type(src)
-			new_known_powers.Add(new_power)
-			new_power.post_gain()
+	for (var/i in length(known_powers) + 1 to level)
+		var/adding_power_type = all_powers[i]
+		var/datum/discipline_power/new_power = new adding_power_type(src)
+		known_powers += new_power
+		new_power.post_gain()
 
-	//delete orphaned powers
-	var/list/datum/discipline_power/leftover_powers = known_powers - new_known_powers
-	if (length(leftover_powers))
+	if (length(known_powers) > level)
+		var/list/datum/discipline_power/leftover_powers = known_powers.Copy(level + 1)
+		known_powers.Cut(level + 1)
 		QDEL_LIST(leftover_powers)
 
-	known_powers = new_known_powers
 	src.level = level
+	update_current_power()
+
+/datum/discipline/proc/update_current_power()
+	level_casting = clamp(level_casting, 1, length(known_powers))
+	current_power = length(known_powers) ? known_powers[level_casting] : null
 
 /**
  * Assigns the Discipline to a mob, setting its owner and applying

--- a/modular_darkpack/modules/powers/code/discipline/__discipline_power.dm
+++ b/modular_darkpack/modules/powers/code/discipline/__discipline_power.dm
@@ -70,13 +70,14 @@
 	src.owner = discipline.owner
 
 /datum/discipline_power/Destroy(force)
-	for(var/i in length(duration_timers))
-		deltimer(duration_timers[i])
+	for(var/timer_id in duration_timers)
+		deltimer(timer_id)
+	duration_timers = null
 	if(cooldown_timer)
 		deltimer(cooldown_timer)
 		cooldown_timer = null
-	QDEL_LIST(duration_timers)
 	grouped_powers = null
+	discipline = null
 	owner = null
 	return ..()
 

--- a/modular_darkpack/modules/powers/code/discipline_actions.dm
+++ b/modular_darkpack/modules/powers/code/discipline_actions.dm
@@ -92,7 +92,7 @@
 	owner.update_action_buttons()
 
 /datum/action/discipline/IsAvailable(feedback)
-	return discipline.current_power.can_activate_untargeted(feedback)
+	return discipline.current_power?.can_activate_untargeted(feedback)
 
 /datum/action/discipline/proc/trigger_level(mob/user, level, trigger_flags)
 	// This proc is for specific levels only, unlike switch_level() it should never roll over to 1 or the max level
@@ -155,11 +155,13 @@
 	if (targeting)
 		end_targeting()
 
-	discipline.current_power = discipline.known_powers[discipline.level_casting]
+	discipline.update_current_power()
+	refresh_power_display()
 
-	// Update name and icon to the new power's
-	name = discipline.current_power.name
-	desc = discipline.current_power.desc
+// Update name, desc, and icon to the new power's
+/datum/action/discipline/proc/refresh_power_display()
+	name = discipline.current_power?.name || discipline.name
+	desc = discipline.current_power?.desc || discipline.desc
 
 	overlay_icon_state = num2text(discipline.level_casting)
 

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/__vampire_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/__vampire_splat.dm
@@ -75,6 +75,7 @@
 		return FALSE
 
 	found_action.discipline.set_level(new_level)
+	found_action.refresh_power_display()
 	return TRUE
 
 /datum/splat/vampire/get_selected_power()


### PR DESCRIPTION

## About The Pull Request

ran into this harddel downstream. this should hopefully fix it?
```
[2026-07-27 00:50:20.585] REFSCANNER: native refscan complete for /datum/discipline_power/bloodheal/one ([0x210ed59c]), took 2539 ms
 - === 1 finding(s)===
 - [finding]    datum #971514 (/datum/discipline/bloodheal).current_power
```

## Why It's Good For The Game

harddel bad

## Changelog
:cl:
fix: Fixed a laggy hard delete related to disciplines.
/:cl:
