### PR TITLE
Fix flaky npc_list runtime in SShumannpcpool

### DIFF
--- a/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
+++ b/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
@@ -37,12 +37,11 @@ SUBSYSTEM_DEF(humannpcpool)
 
 		if (QDELETED(NPC))
 			GLOB.npc_list -= NPC
-			stack_trace("Found a null in npc_list [NPC.type]!")
-			continue
+		else
+			NPC.handle_automated_movement()
 
 		if (MC_TICK_CHECK)
 			return
-		NPC.handle_automated_movement()
 
 /datum/controller/subsystem/humannpcpool/proc/try_repopulate()
 	if (!length(GLOB.npc_spawn_points))


### PR DESCRIPTION
## About The Pull Request

Two fixes in `SShumannpcpool.fire()`.

**Drops a false-positive `stack_trace` that fails integration tests at random.** `fire()` copies `GLOB.npc_list` into `currentrun` and drains it over many ticks (`SS_BACKGROUND`, 0.3s wait, yields on `MC_TICK_CHECK`). Any NPC deleted after the copy is taken is `QDELETED` in the stale copy, which trips the trace. There's no leak to catch: `/mob/living/carbon/human/npc/Destroy()` already does `GLOB.npc_list -= src`, so only the snapshot is out of date. The check can't tell that apart from a real leak, so it fires on the normal case and fails CI. The message is wrong on its face too, since it reads `NPC.type`, which would itself runtime on a genuinely null entry.

Hits intermittently in a downstream fork's CI, on both `runtimetown` and `westfieldmall`. Always the same shape, a burst of different NPC types inside one in-game second, always from the resumed `fire(1)` path.

**Moves `MC_TICK_CHECK` to the end of the loop body.** It ran before `handle_automated_movement()` on an NPC that `--currentrun.len` had already popped, so running out of tick budget skipped that NPC's movement for the whole cycle instead of resuming on it.

Both changes match `SSmobs` in `code/controllers/subsystem/mobs.dm`, which handles the same stale snapshot case by dropping the entry quietly.

## Why It's Good For The Game

The trace removal is CI only, nothing players see. Tests currently fail at random on PRs unrelated to NPCs, which costs re-runs.

The tick check reorder players can notice. NPCs drop a movement tick whenever the subsystem runs out of budget mid-run, so they stutter more than they should under load.

## Changelog

:cl:
fix: NPCs no longer skip a movement tick when the NPC subsystem runs out of tick budget mid-run
code: SShumannpcpool no longer throws a spurious "Found a null in npc_list" runtime when an NPC is deleted mid-run
/:cl: