### PR TITLE
Fixing a bug with firearm's roll

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -613,6 +613,7 @@
 		recoil_roll = new()
 
 	if(COOLDOWN_FINISHED(src, recoil_skill_check))
+		recoil_roll.difficulty = initial(recoil_roll.difficulty)
 		for(var/obj/item/gun/gun in user.held_items)
 			if(gun == src || gun.weapon_weight >= WEAPON_MEDIUM)
 				continue


### PR DESCRIPTION
## About The Pull Request

the lines below only add to recoil_roll's difficulty but never resets or subtracts - making it always trend toward 10 and above.

## Why It's Good For The Game

bug

## Changelog

:cl:

fix: fixes firearms recoil roll difficulty never being reset

/:cl:


