### PR TITLE
Nerfs Acute Hearing

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -305,7 +305,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 // DARKPACK EDIT ADD START - MERITS_FLAWS - (acute sense)
 	if (HAS_TRAIT(src, TRAIT_ACUTE_HEARING) && !HAS_TRAIT(speaker, TRAIT_SIGN_LANG))// we can't HEAR sign, so we don't care for it
-		message_range += 3 // Increase how far we can hear
+		message_range += 1 // Increase how far we can hear
 // DARKPACK EDIT ADD END
 
 	var/atom/movable/virtualspeaker/holopad_speaker = speaker


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've been using this trait and it feels a bit.. too strong.

A person standing 4 tiles away from me can be heard with full clarity, as the 'hearing distance' is effectively the number assigned +1

With this change it changes it from clear coherent hearing at 4 tiles apart down to 2. So you can hear whispers clearly 1 extra tile away, and jarbled ones at another tile after that.

This change does nerf it but it feels still useful, given even if you can't hear full whispers ~3 tiles away from you, you get some of the jarbled text to match it up.

## Why It's Good For The Game

This made whispering really pointless with how many people can hear it. Sure, there's a level of masquerade to it but it makes entire non-masq breaching things whispered heard by a lot of people due to how cheap the trait is.

I feel either this should be merged, or a increase in the merit's cost if it has that range.
 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Reduces bonus tiles on acute hearing from 3 to 1 (hearing whispers 4 tiles away down to 2)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
