### PR TITLE
Resync `install_byond.sh` to TG

### DIFF
--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -14,7 +14,7 @@ else
   rm -rf "$HOME/BYOND"
   mkdir -p "$HOME/BYOND"
   cd "$HOME/BYOND"
-  curl -H "User-Agent: tgstation/1.0 CI Script" "https://spacestation13.github.io/byond-builds/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
+  curl -H "User-Agent: tgstation/1.0 CI Script" "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
   unzip byond.zip
   rm byond.zip
   cd byond


### PR DESCRIPTION

## About The Pull Request
Syncs us back up with TG at https://github.com/tgstation/tgstation/blob/master/tools/ci/install_byond.sh 
The website is missing versions we need and is depricated. 
<img width="866" height="236" alt="image" src="https://github.com/user-attachments/assets/344eb528-e87d-453c-b8c7-ab8b206a731a" />
 And it ought to be a FALLBACK instead of the main option anyway. I will go and pr a fallback url to TG.


