### PR TITLE
allow you to see phone numbers on examine (+ clean up some phone shitcode)

### DIFF
--- a/code/__DEFINES/~darkpack/phones.dm
+++ b/code/__DEFINES/~darkpack/phones.dm
@@ -8,14 +8,6 @@
 #define PHONE_CALLING 2
 #define PHONE_IN_CALL 3
 
-#define PHONE_NO_SIM (1<<1)
-#define PHONE_OPEN (1<<2)
-
-DEFINE_BITFIELD(phone_flags, list(
-	"PHONE_NO_SIM" = PHONE_NO_SIM,
-	"PHONE_OPEN" = PHONE_OPEN,
-))
-
 // Icons used for call history logging
 #define PHONE_CALL_ACCEPTED "fa-phone-volume"
 #define PHONE_CALL_DECLINED "fa-phone-slash"

--- a/modular_darkpack/modules/phones/code/_phone.dm
+++ b/modular_darkpack/modules/phones/code/_phone.dm
@@ -3,6 +3,7 @@
 	desc = "A portable device to call anyone you want."
 	icon = 'modular_darkpack/modules/phones/icons/phone.dmi'
 	ONFLOOR_ICON_HELPER('modular_darkpack/modules/phones/icons/phone_onfloor.dmi')
+	base_icon_state = "phone"
 	icon_state = "phone"
 	inhand_icon_state = "phone"
 	lefthand_file = 'modular_darkpack/modules/phones/icons/lefthand.dmi'
@@ -136,6 +137,8 @@
 	. += span_notice("[EXAMINE_HINT("Alt-Click")] or [EXAMINE_HINT("Right-Click")] to toggle the screen.")
 	if(sim_card)
 		. += span_notice("[EXAMINE_HINT("Ctrl-Click")] to remove [sim_card].")
+		if(sim_card.phone_number && (user.is_holding(src) || isobserver(user)))
+			. += span_notice("Its phone number is [span_bold("[sim_card.phone_number]")].")
 	else
 		. += span_notice("You can [EXAMINE_HINT("Insert")] a SIM card.")
 
@@ -146,20 +149,20 @@
 	ui_interact(user)
 
 /obj/item/smartphone/click_alt(mob/user)
-	if(!(user.is_holding(src)))
+	if(!user.is_holding(src))
 		return CLICK_ACTION_BLOCKING
 	toggle_screen(user)
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/smartphone/item_ctrl_click(mob/user)
-	if(!(user.is_holding(src)))
+	if(!user.is_holding(src))
 		return CLICK_ACTION_BLOCKING
 	if(!sim_card)
 		balloon_alert(user, "no sim card!")
 		return CLICK_ACTION_BLOCKING
 	if(do_after(user, 2 SECONDS, src))
 		balloon_alert(user, "you remove \the [sim_card]!")
-		log_phone("[key_name(usr)] removed a SIM card with the number [sim_card.phone_number].")
+		log_phone("[key_name(user)] removed a SIM card with the number [sim_card.phone_number].")
 		switch(current_state)
 			if(PHONE_CALLING)
 				hang_up_phone_call(dialed_number)
@@ -175,18 +178,25 @@
 	return CLICK_ACTION_BLOCKING
 
 /obj/item/smartphone/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(istype(tool, /obj/item/sim_card))
-		if(sim_card)
-			balloon_alert(user, "[sim_card] already installed!")
-			return ITEM_INTERACT_BLOCKING
-		balloon_alert(user, "you insert \the [tool]!")
-		sim_card = tool
-		user.transferItemToLoc(tool, src)
-		sim_card.phone_weakref = WEAKREF(src)
-		phone_flags &= ~PHONE_NO_SIM
-		log_phone("[key_name(usr)] inserted a SIM card with the number [sim_card.phone_number].")
-		return TRUE
-	return ..()
+	if(!istype(tool, /obj/item/sim_card))
+		return NONE
+	if(sim_card)
+		balloon_alert(user, "[sim_card] already installed!")
+		return ITEM_INTERACT_BLOCKING
+	if(!user.transferItemToLoc(tool, src))
+		balloon_alert(user, "failed to install [tool]!")
+		return ITEM_INTERACT_BLOCKING
+	balloon_alert(user, "you insert \the [tool]!")
+	sim_card = tool
+	sim_card.phone_weakref = WEAKREF(src)
+	phone_flags &= ~PHONE_NO_SIM
+	log_phone("[key_name(user)] inserted a SIM card with the number [sim_card.phone_number].")
+	return ITEM_INTERACT_SUCCESS
+
+/obj/item/smartphone/update_icon_state()
+	. = ..()
+	icon_state = (phone_flags & PHONE_OPEN) ? "[base_icon_state]_on" : base_icon_state
+	inhand_icon_state = (phone_flags & PHONE_OPEN) ? "[base_icon_state]_on" : base_icon_state
 
 /obj/item/smartphone/ui_status(mob/user, datum/ui_state/state)
 	if(!(phone_flags & PHONE_OPEN))
@@ -194,14 +204,15 @@
 	return ..()
 
 /obj/item/smartphone/ui_interact(mob/user, datum/tgui/ui)
-	. = ..()
-	var/datum/asset/background_files = get_asset_datum(/datum/asset/simple/phone_assets)
-	if(user.client)
-		background_files.send(user.client)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Telephone")
 		ui.open()
+
+/obj/item/smartphone/ui_assets(mob/user)
+	return list(
+		get_asset_datum(/datum/asset/simple/phone_assets),
+	)
 
 /obj/item/smartphone/ui_data(mob/living/user)
 	var/list/data = list()
@@ -302,14 +313,16 @@
 
 	return data
 
-/obj/item/smartphone/ui_act(action, params, datum/tgui/ui)
+/obj/item/smartphone/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
+
+	var/mob/user = ui.user
 	switch(action)
 		if("call")
-			start_phone_call(usr, params["number"])
-			log_phone("[key_name(usr)] called [params["number"]].")
+			start_phone_call(user, params["number"])
+			log_phone("[key_name(user)] called [params["number"]].")
 			return TRUE
 
 		if("hang")
@@ -320,93 +333,93 @@
 			return TRUE
 
 		if("accept")
-			accept_phone_call(usr)
-			log_phone("[key_name(usr)] answered a phone call.")
+			accept_phone_call(user)
+			log_phone("[key_name(user)] answered a phone call.")
 			return TRUE
 
 		if("decline")
 			decline_phone_call()
-			log_phone("[key_name(usr)] declined a phone call.")
+			log_phone("[key_name(user)] declined a phone call.")
 			return TRUE
 
 		if("publish_number")
-			to_chat(usr, span_notice("This text will represent you in the phonebook. example: Jane Doe | Anarchy Rose Manager"))
-			var/name = tgui_input_text(usr, "Phonebook Name", "Publish Number")
+			to_chat(user, span_notice("This text will represent you in the phonebook. example: Jane Doe | Anarchy Rose Manager"))
+			var/name = tgui_input_text(user, "Phonebook Name", "Publish Number", max_length = MAX_MESSAGE_LEN)
 			if(!name)
-				to_chat(usr, span_danger("You must input text to publish your number."))
+				to_chat(user, span_danger("You must input text to publish your number."))
 				return
 			if(!sim_card)
-				to_chat(usr, span_danger("You must insert a SIM card to publish your number."))
+				to_chat(user, span_danger("You must insert a SIM card to publish your number."))
 				return
-			name = trim(copytext_char(sanitize(name), 1, MAX_MESSAGE_LEN))
 			for(var/contact in SSphones.published_phone_numbers)
 				if(SSphones.published_phone_numbers[contact] == sim_card.phone_number)
-					to_chat(usr, span_danger("Error: This number is already published."))
+					to_chat(user, span_danger("Error: This number is already published."))
 					return TRUE
 			SSphones.published_phone_numbers[name] = sim_card.phone_number
-			to_chat(usr, span_notice("Your number is now published."))
+			to_chat(user, span_notice("Your number is now published."))
 			sim_card.published = TRUE
 			sim_card.published_name = name
-			log_phone("[key_name(usr)] published their number ([name])/[sim_card.phone_number] to the phonebook.")
+			log_phone("[key_name(user)] published their number ([name])/[sim_card.phone_number] to the phonebook.")
 			return TRUE
 
 		if("unpublish_number")
 			for(var/contact in SSphones.published_phone_numbers)
-				if(SSphones.published_phone_numbers[contact] == sim_card.phone_number)
-					log_phone("[key_name(usr)] unpublished their number ([contact])/[sim_card.phone_number] from the phonebook.")
-					SSphones.published_phone_numbers.Remove(contact)
-					sim_card.published = FALSE
-					sim_card.published_name = null
-					to_chat(usr, span_notice("Your number is now unpublished."))
-					return TRUE
+				if(SSphones.published_phone_numbers[contact] != sim_card.phone_number)
+					continue
+				log_phone("[key_name(user)] unpublished their number ([contact])/[sim_card.phone_number] from the phonebook.")
+				SSphones.published_phone_numbers -= contact
+				sim_card.published = FALSE
+				sim_card.published_name = null
+				to_chat(user, span_notice("Your number is now unpublished."))
+				return TRUE
 
 		if("custom_background")
-			to_chat(usr, span_danger("Do NOT use images that can be considered offensive or obscene, or that contain references to something that happened after the year [CURRENT_STATION_YEAR]. Recommended image dimensions: 400x600 "))
-			custom_background = tgui_input_text(usr, "Input background image URL", "Custom Background")
+			to_chat(user, span_danger("Do NOT use images that can be considered offensive or obscene, or that contain references to something that happened after the year [CURRENT_STATION_YEAR]. Recommended image dimensions: 400x600 "))
+			custom_background = tgui_input_text(user, "Input background image URL", "Custom Background")
 			if(!custom_background)
-				to_chat(usr, span_danger("You must input a URL to set a custom background."))
+				to_chat(user, span_danger("You must input a URL to set a custom background."))
 				return
 			phone_background = custom_background
-			log_phone("[key_name(usr)] set a custom background image on [src]: [custom_background]")
+			log_phone("[key_name(user)] set a custom background image on [src]: [custom_background]")
 			return TRUE
 
 		if("add_contact")
-			var/number = tgui_input_text(usr, "Input number", "Add Contact")
+			var/number = tgui_input_text(user, "Input number", "Add Contact")
 			if(length(number) > 15)
-				to_chat(usr, span_danger("Entered number is too long"))
+				to_chat(user, span_danger("Entered number is too long"))
 				return FALSE
 			var/stripped_number = replacetext(number, " ", "") // remove spaces
-			var/new_contact_name = tgui_input_text(usr, "Input name", "Add Contact")
+			var/new_contact_name = tgui_input_text(user, "Input name", "Add Contact")
 			if(!new_contact_name || !number)
-				to_chat(usr, span_danger("You must provide both a name and a number."))
+				to_chat(user, span_danger("You must provide both a name and a number."))
 				return FALSE
 
 			var/datum/phonecontact/new_contact = new()
 			new_contact.number = "[stripped_number]"
 			new_contact.name = "[new_contact_name]"
 			contacts += new_contact
-			log_phone("[key_name(usr)] added a new contact: [new_contact_name] ([stripped_number])")
+			log_phone("[key_name(user)] added a new contact: [new_contact_name] ([stripped_number])")
 			return TRUE
 
 		if("remove_contact")
-			var/number = tgui_input_text(usr, "Input number", "Remove Contact")
+			var/number = tgui_input_text(user, "Input number", "Remove Contact")
 			if(length(number) > 15)
-				to_chat(usr, span_danger("Entered number is too long"))
+				to_chat(user, span_danger("Entered number is too long"))
 				return FALSE
 			for(var/datum/phonecontact/contact in contacts)
 				if(contact.number == number)
 					contacts -= contact
-					log_phone("[key_name(usr)] removed a contact with number: [number]")
+					log_phone("[key_name(user)] removed a contact with number: [number]")
 					return TRUE
 			return FALSE
 
 		if("block")
-			var/block_number = tgui_input_text(usr, "Input number to block", "Block Contact")
+			var/block_number = tgui_input_text(user, "Input number to block", "Block Contact")
 			if(!block_number)
-				to_chat(usr, span_warning("You must provide a number."))
+				to_chat(user, span_warning("You must provide a number."))
 				return FALSE
 			if(length(block_number) > 15)
-				to_chat(usr, span_warning("Invalid number."))
+				to_chat(user, span_warning("Invalid number."))
 				return FALSE
 
 			var/datum/phonecontact/blocked_contact = new()
@@ -417,9 +430,9 @@
 			return TRUE
 
 		if("unblock")
-			var/result = tgui_input_text(usr, "Input number to unblock", "Unblock Contact")
+			var/result = tgui_input_text(user, "Input number to unblock", "Unblock Contact")
 			if(!result)
-				to_chat(usr, span_warning("You must provide a number."))
+				to_chat(user, span_warning("You must provide a number."))
 				return FALSE
 			for(var/datum/phonecontact/unblocked_contact in blocked_contacts)
 				if(unblocked_contact.name == result)
@@ -429,25 +442,22 @@
 
 		if("delete_call_history")
 			if(!length(phone_history_list))
-				to_chat(usr, span_danger("You have no call history to delete."))
+				to_chat(user, span_danger("You have no call history to delete."))
 				return FALSE
 
-			to_chat(usr, "Your total amount of history saved is: [length(phone_history_list)]")
-			var/number_of_deletions = tgui_input_number(usr, "Input the amount that you want to delete", "Deletion Amount", max_value = length(phone_history_list))
+			to_chat(user, span_notice("Your total amount of history saved is: [length(phone_history_list)]"))
+			var/number_of_deletions = tgui_input_number(user, "Input the amount that you want to delete", "Deletion Amount", max_value = length(phone_history_list))
 			if(!number_of_deletions)
 				return FALSE
 
 			//Delete the call history depending on the amount inputed by the User
 			if(number_of_deletions > length(phone_history_list))
 				//Verify if the requested amount in bigger than the history list.
-				to_chat(usr, "You cannot delete more items than the history contains.")
+				to_chat(user, span_warning("You cannot delete more items than the history contains."))
 				return FALSE
 			else
-				for(var/i in 1 to number_of_deletions)
-					//It will always delete the first item of the list, so the last logs are deleted first
-					var/item_to_remove = phone_history_list[1]
-					phone_history_list -= item_to_remove
-			to_chat(usr, "[number_of_deletions] call history entries were deleted. Remaining: [length(phone_history_list)]")
+				phone_history_list.Cut(1, number_of_deletions + 1)
+			to_chat(user, span_notice("[number_of_deletions] call history entries were deleted. Remaining: [length(phone_history_list)]"))
 			return TRUE
 
 		if("terminal_sound")
@@ -457,21 +467,21 @@
 
 		if("silent")
 			ringer = !ringer
-			balloon_alert(usr, "ringer [ringer ? "on" : "off"]!")
+			balloon_alert(user, "ringer [ringer ? "on" : "off"]!")
 			return TRUE
 
 		if("vibration")
 			vibration = !vibration
-			balloon_alert(usr, "vibration [vibration ? "on" : "off"]!")
+			balloon_alert(user, "vibration [vibration ? "on" : "off"]!")
 			return TRUE
 
 		if("speaker")
 			if(phone_radio.canhear_range == 1)
 				phone_radio.canhear_range = 3
-				balloon_alert(usr, "speaker on!")
+				balloon_alert(user, "speaker on!")
 			else
 				phone_radio.canhear_range = 1
-				balloon_alert(usr, "speaker off!")
+				balloon_alert(user, "speaker off!")
 			return TRUE
 
 		if("set_background")
@@ -481,10 +491,10 @@
 		if("mute")
 			muted = !muted
 			phone_radio.set_listening(!muted)
-			balloon_alert(usr, "[muted ? "muted" : "unmuted"]!")
+			balloon_alert(user, "[muted ? "muted" : "unmuted"]!")
 
 		if("wiki")
-			wiki_book.display_content(usr)
+			wiki_book.display_content(user)
 
 		if("view_conversation")
 			current_viewed_conversation = params["contact_number"]
@@ -494,22 +504,24 @@
 			return TRUE
 
 		if("submit_post")
-			submit_post(params["body"])
+			submit_post(user, params["body"])
 			return TRUE
 
 		if("endpost_registration")
-			endpost_registration()
+			endpost_registration(user)
 			return TRUE
 
 		if("remove_endpost")
+			if(!is_admin(user.client))
+				CRASH("Non-admin somehow tried to call remove_endpost")
 			var/post_index = text2num(params["post_index"])
 			if(!post_index)
-				to_chat(usr, "Invalid post index.")
+				to_chat(user, span_warning("Invalid post index."))
 				return FALSE
 			var/list/selected_post = SSphones.endpost_posts[post_index]
 			SSphones.endpost_posts.Cut(post_index, post_index + 1)
-			to_chat(usr, "Post '[selected_post["body"]]' by [selected_post["author"]] removed.")
-			log_phone("[key_name(usr)] removed an endpost: [selected_post["body"]] by [selected_post["author"]]", list("author" = selected_post["author"], "body" = selected_post["body"]))
+			to_chat(user, span_notice("Post '[selected_post["body"]]' by [selected_post["author"]] removed."))
+			log_phone("[key_name(user)] removed an endpost: [selected_post["body"]] by [selected_post["author"]]", list("author" = selected_post["author"], "body" = selected_post["body"]))
 			return TRUE
 
 		if("keyboard_click")
@@ -522,7 +534,7 @@
 			var/message_text = params["message_text"]
 			if(!contact_number || !message_text)
 				return FALSE
-			send_text_message(contact_number, message_text)
+			send_text_message(user, contact_number, message_text)
 			if(ringer)
 				playsound(loc, 'modular_darkpack/modules/phones/sounds/text_send.ogg', 50, TRUE)
 			return TRUE
@@ -534,7 +546,7 @@
 		if(convo.contact_number == contact_number)
 			return convo
 
-/obj/item/smartphone/proc/send_text_message(contact_number, message_text)
+/obj/item/smartphone/proc/send_text_message(mob/user, contact_number, message_text)
 	if(!contact_number || !message_text)
 		return FALSE
 
@@ -556,7 +568,7 @@
 			receiving_phone.conversations += recv_conversation
 		recv_conversation.add_message(message_text, FALSE)
 		addtimer(CALLBACK(receiving_phone, PROC_REF(after_text_received), contact_name, message_text), rand(1 SECONDS, 2 SECONDS)) //simulate random delay before sending an audible/visible alert
-		log_phone("[key_name(usr)] sent a text to [contact_number]: [message_text]", list("sender" = contact_name, "receiver" = recv_contact_name, "message" = message_text))
+		log_phone("[key_name(user)] sent a text to [contact_number]: [message_text]", list("sender" = contact_name, "receiver" = recv_contact_name, "message" = message_text))
 	return TRUE
 
 //stuff to do after a text is received
@@ -587,11 +599,9 @@
 		phone_flags &= ~PHONE_OPEN
 	else
 		phone_flags |= PHONE_OPEN
-	icon_state = (phone_flags & PHONE_OPEN) ? "phone_on" : "phone"
-	inhand_icon_state = (phone_flags & PHONE_OPEN) ? "phone_on" : "phone"
-	update_icon()
+	update_appearance(UPDATE_ICON_STATE)
 
-/obj/item/smartphone/proc/submit_post(body)
+/obj/item/smartphone/proc/submit_post(mob/user, body)
 	if(!body)
 		return FALSE
 
@@ -606,13 +616,13 @@
 	)
 
 	UNTYPED_LIST_ADD(SSphones.endpost_posts, new_post)
-	log_phone("[key_name(usr)] submitted a new endpost: [trim(body)] as [endpost_username]")
+	log_phone("[key_name(user)] submitted a new endpost: [trim(body)] as [endpost_username]")
 
 	return TRUE
 
-/obj/item/smartphone/proc/endpost_registration()
-	var/new_username = tgui_input_text(usr, "Choose your username:", "EndPost Registration", "", 14) //max size of 14 chars or it starts bumping elements around
-	log_phone("[key_name(usr)] [endpost_username ? "updated" : "registered"] their username as [new_username]")
+/obj/item/smartphone/proc/endpost_registration(mob/user)
+	var/new_username = tgui_input_text(user, "Choose your username:", "EndPost Registration", max_length = 14) //max size of 14 chars or it starts bumping elements around
+	log_phone("[key_name(user)] [endpost_username ? "updated" : "registered"] their username as [new_username]")
 	endpost_username = new_username
 	return TRUE
 

--- a/modular_darkpack/modules/phones/code/_phone.dm
+++ b/modular_darkpack/modules/phones/code/_phone.dm
@@ -45,8 +45,6 @@
 	var/ringer = TRUE
 	// If the phone shows balloon alerts when ringing.
 	var/vibration = TRUE
-	// Passive particle effect generation for when on call
-	var/obj/effect/abstract/particle_holder/particle_generator
 	// If the phone's microphone is muted.
 	var/muted = FALSE
 	// ID of the timer that the phone uses for ringing. Deleted once the user denies a phone call or misses it.
@@ -116,8 +114,7 @@
 			if(our_contact.number == sim_card.phone_number)
 				contact_network.contacts -= our_contact
 
-	if(particle_generator)
-		QDEL_NULL(particle_generator)
+	remove_shared_particles(/particles/phone_ringing)
 
 	lose_hearing_sensitivity(ROUNDSTART_TRAIT)
 	UnregisterSignal(src, COMSIG_MOVABLE_HEAR)
@@ -474,6 +471,8 @@
 		if("silent")
 			ringer = !ringer
 			balloon_alert(user, "ringer [ringer ? "on" : "off"]!")
+			if(!ringer)
+				remove_shared_particles(/particles/phone_ringing)
 			return TRUE
 
 		if("vibration")

--- a/modular_darkpack/modules/phones/code/_phone.dm
+++ b/modular_darkpack/modules/phones/code/_phone.dm
@@ -31,6 +31,8 @@
 	var/obj/item/book/manual/wiki/wiki_book
 	// Is the phone opened?
 	var/opened = FALSE
+	/// Is this phone always open?
+	var/always_open = FALSE
 	// The phone's current state.
 	VAR_PRIVATE/current_state = PHONE_AVAILABLE
 	// The number the phone has dialed.
@@ -599,7 +601,7 @@
 	return formatted_messages
 
 /obj/item/smartphone/proc/toggle_screen(mob/user)
-	opened = !opened
+	opened = always_open || !opened
 	update_appearance(UPDATE_ICON_STATE)
 
 /obj/item/smartphone/proc/submit_post(mob/user, body)

--- a/modular_darkpack/modules/phones/code/_phone.dm
+++ b/modular_darkpack/modules/phones/code/_phone.dm
@@ -116,7 +116,7 @@
 			if(our_contact.number == sim_card.phone_number)
 				contact_network.contacts -= our_contact
 
-	remove_shared_particles(/particles/phone_ringing)
+	remove_shared_particles(/particles/phone_ringing, delete_on_empty = FALSE)
 
 	lose_hearing_sensitivity(ROUNDSTART_TRAIT)
 	UnregisterSignal(src, COMSIG_MOVABLE_HEAR)
@@ -474,7 +474,7 @@
 			ringer = !ringer
 			balloon_alert(user, "ringer [ringer ? "on" : "off"]!")
 			if(!ringer)
-				remove_shared_particles(/particles/phone_ringing)
+				remove_shared_particles(/particles/phone_ringing, delete_on_empty = FALSE)
 			return TRUE
 
 		if("vibration")

--- a/modular_darkpack/modules/phones/code/_phone.dm
+++ b/modular_darkpack/modules/phones/code/_phone.dm
@@ -27,6 +27,8 @@
 	var/obj/machinery/newscaster/irc_channel
 	// Do we have a SIM card?
 	var/obj/item/sim_card/sim_card
+	/// If we should spawn a SIM card as init, what should its type be?
+	var/default_sim_card_type = /obj/item/sim_card
 	// There's a wiki in our phone. Literally.
 	var/obj/item/book/manual/wiki/wiki_book
 	// Is the phone opened?
@@ -68,8 +70,8 @@
 /obj/item/smartphone/Initialize(mapload)
 	. = ..()
 	GLOB.phones_list += src
-	if(!sim_card)
-		sim_card = new()
+	if(!sim_card && default_sim_card_type)
+		sim_card = new default_sim_card_type(src)
 		sim_card.phone_weakref = WEAKREF(src)
 	phone_radio = new(src)
 	phone_radio.keyslot = new

--- a/modular_darkpack/modules/phones/code/_phone.dm
+++ b/modular_darkpack/modules/phones/code/_phone.dm
@@ -197,8 +197,8 @@
 
 /obj/item/smartphone/update_icon_state()
 	. = ..()
-	icon_state = opened ? "[base_icon_state]_on" : base_icon_state
-	inhand_icon_state = opened ? "[base_icon_state]_on" : base_icon_state
+	icon_state = (opened && !always_open) ? "[base_icon_state]_on" : base_icon_state
+	inhand_icon_state = (opened && !always_open) ? "[base_icon_state]_on" : base_icon_state
 
 /obj/item/smartphone/ui_status(mob/user, datum/ui_state/state)
 	if(!opened)

--- a/modular_darkpack/modules/phones/code/_phone.dm
+++ b/modular_darkpack/modules/phones/code/_phone.dm
@@ -29,8 +29,8 @@
 	var/obj/item/sim_card/sim_card
 	// There's a wiki in our phone. Literally.
 	var/obj/item/book/manual/wiki/wiki_book
-	// Phone flags, for things like if its open or if it has no sim card.
-	var/phone_flags = NONE
+	// Is the phone opened?
+	var/opened = FALSE
 	// The phone's current state.
 	VAR_PRIVATE/current_state = PHONE_AVAILABLE
 	// The number the phone has dialed.
@@ -144,7 +144,7 @@
 
 /obj/item/smartphone/attack_self(mob/user, modifiers)
 	. = ..()
-	if(!(phone_flags & PHONE_OPEN))
+	if(!opened)
 		toggle_screen(user)
 	ui_interact(user)
 
@@ -173,7 +173,6 @@
 		user.put_in_hands(sim_card)
 		sim_card.phone_weakref = null
 		sim_card = null
-		phone_flags |= PHONE_NO_SIM
 		return CLICK_ACTION_SUCCESS
 	return CLICK_ACTION_BLOCKING
 
@@ -189,17 +188,16 @@
 	balloon_alert(user, "you insert \the [tool]!")
 	sim_card = tool
 	sim_card.phone_weakref = WEAKREF(src)
-	phone_flags &= ~PHONE_NO_SIM
 	log_phone("[key_name(user)] inserted a SIM card with the number [sim_card.phone_number].")
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/smartphone/update_icon_state()
 	. = ..()
-	icon_state = (phone_flags & PHONE_OPEN) ? "[base_icon_state]_on" : base_icon_state
-	inhand_icon_state = (phone_flags & PHONE_OPEN) ? "[base_icon_state]_on" : base_icon_state
+	icon_state = opened ? "[base_icon_state]_on" : base_icon_state
+	inhand_icon_state = opened ? "[base_icon_state]_on" : base_icon_state
 
 /obj/item/smartphone/ui_status(mob/user, datum/ui_state/state)
-	if(!(phone_flags & PHONE_OPEN))
+	if(!opened)
 		return UI_CLOSE
 	return ..()
 
@@ -216,8 +214,12 @@
 
 /obj/item/smartphone/ui_data(mob/living/user)
 	var/list/data = list()
-	data["my_number"] = sim_card ? sim_card.phone_number : "No SIM card inserted."
-	data["no_sim_card"] = (phone_flags & PHONE_NO_SIM) ? TRUE : FALSE
+	if(sim_card)
+		data["my_number"] = sim_card.phone_number
+		data["no_sim_card"] = FALSE
+	else
+		data["my_number"] = "No SIM card inserted"
+		data["no_sim_card"] = TRUE
 	data["phone_in_call"] = (current_state == PHONE_IN_CALL) ? TRUE : FALSE
 	data["phone_ringing"] = (current_state == PHONE_RINGING) ? TRUE : FALSE
 	data["phone_calling"] = (current_state == PHONE_CALLING) ? TRUE : FALSE
@@ -595,10 +597,7 @@
 	return formatted_messages
 
 /obj/item/smartphone/proc/toggle_screen(mob/user)
-	if(phone_flags & PHONE_OPEN)
-		phone_flags &= ~PHONE_OPEN
-	else
-		phone_flags |= PHONE_OPEN
+	opened = !opened
 	update_appearance(UPDATE_ICON_STATE)
 
 /obj/item/smartphone/proc/submit_post(mob/user, body)

--- a/modular_darkpack/modules/phones/code/_phone.dm
+++ b/modular_darkpack/modules/phones/code/_phone.dm
@@ -173,6 +173,7 @@
 		user.put_in_hands(sim_card)
 		sim_card.phone_weakref = null
 		sim_card = null
+		SStgui.update_uis(src)
 		return CLICK_ACTION_SUCCESS
 	return CLICK_ACTION_BLOCKING
 
@@ -189,6 +190,7 @@
 	sim_card = tool
 	sim_card.phone_weakref = WEAKREF(src)
 	log_phone("[key_name(user)] inserted a SIM card with the number [sim_card.phone_number].")
+	SStgui.update_uis(src)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/smartphone/update_icon_state()

--- a/modular_darkpack/modules/phones/code/phone_effects.dm
+++ b/modular_darkpack/modules/phones/code/phone_effects.dm
@@ -10,8 +10,3 @@
 	gravity = list(0, 0.1)
 	position = generator(GEN_SPHERE, 0, 16, NORMAL_RAND)
 	spin = generator(GEN_NUM, -1, 1, NORMAL_RAND)
-
-
-/obj/item/smartphone/proc/setup_particles()
-	if(!particle_generator)
-		particle_generator = new(src, /particles/phone_ringing, PARTICLE_ATTACH_MOB)

--- a/modular_darkpack/modules/phones/code/phone_procs.dm
+++ b/modular_darkpack/modules/phones/code/phone_procs.dm
@@ -69,7 +69,7 @@
 		STOP_PROCESSING(SSprocessing, src)
 
 /obj/item/smartphone/proc/check_missing_sim_card(mob/user)
-	if(phone_flags & PHONE_NO_SIM)
+	if(QDELETED(sim_card))
 		balloon_alert(user, "no SIM!")
 		return TRUE
 	return FALSE

--- a/modular_darkpack/modules/phones/code/phone_procs.dm
+++ b/modular_darkpack/modules/phones/code/phone_procs.dm
@@ -59,13 +59,12 @@
 	if(current_state == PHONE_RINGING)
 		START_PROCESSING(SSprocessing, src)
 		if(ringer)
-			setup_particles()
+			add_shared_particles(/particles/phone_ringing, particle_flags = PARTICLE_ATTACH_MOB)
 
 	if(current_state == PHONE_IN_CALL || current_state == PHONE_AVAILABLE)
 		if(phone_ringing_timer)
 			deltimer(phone_ringing_timer)
-		if(particle_generator)
-			QDEL_NULL(particle_generator)
+			phone_ringing_timer = null
 		STOP_PROCESSING(SSprocessing, src)
 
 /obj/item/smartphone/proc/check_missing_sim_card(mob/user)

--- a/modular_darkpack/modules/phones/code/phone_procs.dm
+++ b/modular_darkpack/modules/phones/code/phone_procs.dm
@@ -61,10 +61,11 @@
 		if(ringer)
 			add_shared_particles(/particles/phone_ringing, particle_flags = PARTICLE_ATTACH_MOB)
 
-	if(current_state == PHONE_IN_CALL || current_state == PHONE_AVAILABLE)
+	else if(current_state == PHONE_IN_CALL || current_state == PHONE_AVAILABLE)
 		if(phone_ringing_timer)
 			deltimer(phone_ringing_timer)
 			phone_ringing_timer = null
+		remove_shared_particles(/particles/phone_ringing, delete_on_empty = FALSE)
 		STOP_PROCESSING(SSprocessing, src)
 
 /obj/item/smartphone/proc/check_missing_sim_card(mob/user)

--- a/modular_darkpack/modules/phones/code/phone_subsystem.dm
+++ b/modular_darkpack/modules/phones/code/phone_subsystem.dm
@@ -15,6 +15,12 @@ SUBSYSTEM_DEF(phones)
 	// Posts for the endpost feed
 	var/list/endpost_posts = list()
 
+/datum/controller/subsystem/phones/Recover()
+	assigned_phone_numbers = SSphones.assigned_phone_numbers
+	frequencies_in_use = SSphones.frequencies_in_use
+	published_phone_numbers = SSphones.published_phone_numbers
+	endpost_posts = SSphones.endpost_posts
+
 // Generates a random phone number from the available ranges, ten digits, starts with a 415 or 628.
 /datum/controller/subsystem/phones/proc/random_number()
 	return "[pick("415","628")][rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)]"
@@ -59,5 +65,4 @@ SUBSYSTEM_DEF(phones)
 	for(var/obj/item/sim_card/sim_card as anything in assigned_phone_numbers)
 		if(sim_card.phone_number == phone_number)
 			gotten_sim_card = sim_card
-	var/gotten_phone = gotten_sim_card?.phone_weakref?.resolve()
-	return gotten_phone
+	return gotten_sim_card?.phone_weakref?.resolve()

--- a/modular_darkpack/modules/phones/code/stationary_subtypes.dm
+++ b/modular_darkpack/modules/phones/code/stationary_subtypes.dm
@@ -5,12 +5,12 @@
 	icon = 'modular_darkpack/modules/phones/icons/phone.dmi'
 	icon_state = "payphone"
 	anchored = TRUE
+	opened = TRUE
 
 /obj/item/smartphone/payphone/Initialize(mapload)
 	sim_card = new /obj/item/sim_card/landline()
 	sim_card.phone_weakref = WEAKREF(src)
-	phone_flags |= PHONE_OPEN
-	. = ..()
+	return ..()
 
 /obj/item/smartphone/payphone/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -23,12 +23,12 @@
 	icon = 'modular_darkpack/modules/phones/icons/phone.dmi'
 	icon_state = "phone_black"
 	anchored = TRUE
+	opened = TRUE
 
 /obj/item/smartphone/clean/Initialize(mapload)
 	sim_card = new /obj/item/sim_card/cleaner()
 	sim_card.phone_weakref = WEAKREF(src)
-	phone_flags |= PHONE_OPEN
-	. = ..()
+	return ..()
 
 /obj/item/smartphone/clean/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -41,12 +41,12 @@
 	icon = 'modular_darkpack/modules/phones/icons/phone.dmi'
 	icon_state = "phone_red"
 	anchored = TRUE
+	opened = TRUE
 
 /obj/item/smartphone/emergency/Initialize(mapload)
 	sim_card = new /obj/item/sim_card/emergency()
 	sim_card.phone_weakref = WEAKREF(src)
-	phone_flags |= PHONE_OPEN
-	. = ..()
+	return ..()
 
 /obj/item/smartphone/emergency/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/modular_darkpack/modules/phones/code/stationary_subtypes.dm
+++ b/modular_darkpack/modules/phones/code/stationary_subtypes.dm
@@ -8,11 +8,7 @@
 	anchored = TRUE
 	opened = TRUE
 	always_open = TRUE
-
-/obj/item/smartphone/payphone/Initialize(mapload)
-	sim_card = new /obj/item/sim_card/landline()
-	sim_card.phone_weakref = WEAKREF(src)
-	return ..()
+	default_sim_card_type = /obj/item/sim_card/landline
 
 /obj/item/smartphone/payphone/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -28,11 +24,7 @@
 	anchored = TRUE
 	opened = TRUE
 	always_open = TRUE
-
-/obj/item/smartphone/clean/Initialize(mapload)
-	sim_card = new /obj/item/sim_card/cleaner()
-	sim_card.phone_weakref = WEAKREF(src)
-	return ..()
+	default_sim_card_type = /obj/item/sim_card/cleaner
 
 /obj/item/smartphone/clean/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -48,11 +40,7 @@
 	anchored = TRUE
 	opened = TRUE
 	always_open = TRUE
-
-/obj/item/smartphone/emergency/Initialize(mapload)
-	sim_card = new /obj/item/sim_card/emergency()
-	sim_card.phone_weakref = WEAKREF(src)
-	return ..()
+	default_sim_card_type = /obj/item/sim_card/emergency
 
 /obj/item/smartphone/emergency/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/modular_darkpack/modules/phones/code/stationary_subtypes.dm
+++ b/modular_darkpack/modules/phones/code/stationary_subtypes.dm
@@ -3,9 +3,11 @@
 	desc = "Ring ring. Ring ring. Ring ring."
 	ONFLOOR_ICON_HELPER(null)
 	icon = 'modular_darkpack/modules/phones/icons/phone.dmi'
+	base_icon_state = "payphone"
 	icon_state = "payphone"
 	anchored = TRUE
 	opened = TRUE
+	always_open = TRUE
 
 /obj/item/smartphone/payphone/Initialize(mapload)
 	sim_card = new /obj/item/sim_card/landline()
@@ -21,9 +23,11 @@
 	desc = "The usual phone of a cleaning company used to communicate with employees"
 	ONFLOOR_ICON_HELPER(null)
 	icon = 'modular_darkpack/modules/phones/icons/phone.dmi'
+	base_icon_state = "phone_black"
 	icon_state = "phone_black"
 	anchored = TRUE
 	opened = TRUE
+	always_open = TRUE
 
 /obj/item/smartphone/clean/Initialize(mapload)
 	sim_card = new /obj/item/sim_card/cleaner()
@@ -39,9 +43,11 @@
 	desc = "A phone used for emergency calls."
 	ONFLOOR_ICON_HELPER(null)
 	icon = 'modular_darkpack/modules/phones/icons/phone.dmi'
+	base_icon_state = "phone_red"
 	icon_state = "phone_red"
 	anchored = TRUE
 	opened = TRUE
+	always_open = TRUE
 
 /obj/item/smartphone/emergency/Initialize(mapload)
 	sim_card = new /obj/item/sim_card/emergency()


### PR DESCRIPTION

## About The Pull Request

made it so you can see a phone's number by examining it (albeit you have to be holding it)

also did a lot of shitcode cleanup. it's still kinda shitcode but it's slightly a tiny bit better now.


also deleting endpost forums only checked for admin client-side lmao

## Why It's Good For The Game

kinda stupid you have to call someone else / get someone else to look at ur published number to see ur own phone number

too lazy to make it a memory so this is better for now i guess

also shitcode cleanup good

## Changelog
:cl:
qol: You can now see your phone number by examining your phone.
code: Cleaned up a lot of phone shitcode.
/:cl:
