### PR TITLE
don't spawn NPCs during unit tests (+minor `SShumannpcpool` fixes)

### DIFF
--- a/modular_darkpack/modules/npc/code/human/__npc.dm
+++ b/modular_darkpack/modules/npc/code/human/__npc.dm
@@ -133,6 +133,7 @@
 	drop_on_death_list = null
 	GLOB.npc_list -= src
 	GLOB.alive_npc_list -= src
+	SShumannpcpool.currentrun -= src
 	SShumannpcpool.try_repopulate()
 	return ..()
 

--- a/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
+++ b/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
@@ -41,7 +41,8 @@ SUBSYSTEM_DEF(humannpcpool)
 
 		if (QDELETED(NPC))
 			GLOB.npc_list -= NPC
-			stack_trace("Found a null in npc_list [NPC.type]!")
+			if(isnull(NPC))
+				stack_trace("Found a null in npc_list [NPC.type]!")
 			continue
 
 		if (MC_TICK_CHECK)

--- a/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
+++ b/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
@@ -27,14 +27,11 @@ SUBSYSTEM_DEF(humannpcpool)
 	return ..()
 
 /datum/controller/subsystem/humannpcpool/fire(resumed = FALSE)
-
-	if (!resumed)
-		var/list/activelist = GLOB.npc_list
-		src.currentrun = activelist.Copy()
+	if(!resumed)
+		src.currentrun = GLOB.npc_list.Copy()
 
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
-
 	while(length(currentrun))
 		var/mob/living/carbon/human/npc/NPC = currentrun[length(currentrun)]
 		--currentrun.len

--- a/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
+++ b/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
@@ -35,19 +35,12 @@ SUBSYSTEM_DEF(humannpcpool)
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
 
-	while(currentrun.len)
-		var/mob/living/carbon/human/npc/NPC = currentrun[currentrun.len]
+	while(length(currentrun))
+		var/mob/living/carbon/human/npc/NPC = currentrun[length(currentrun)]
 		--currentrun.len
-
-		if (QDELETED(NPC))
-			GLOB.npc_list -= NPC
-			if(isnull(NPC))
-				stack_trace("Found a null in npc_list [NPC.type]!")
-			continue
-
-		if (MC_TICK_CHECK)
+		NPC?.handle_automated_movement()
+		if(MC_TICK_CHECK)
 			return
-		NPC.handle_automated_movement()
 
 /datum/controller/subsystem/humannpcpool/proc/try_repopulate()
 #ifndef UNIT_TESTS

--- a/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
+++ b/modular_darkpack/modules/npc/code/human/npc_human_subsystem.dm
@@ -1,6 +1,10 @@
 SUBSYSTEM_DEF(humannpcpool)
 	name = "Human NPC Pool"
-	ss_flags = SS_POST_FIRE_TIMING|SS_BACKGROUND
+#ifndef UNIT_TESTS
+	ss_flags = SS_POST_FIRE_TIMING | SS_BACKGROUND
+#else
+	ss_flags = SS_NO_INIT | SS_NO_FIRE
+#endif
 	priority = FIRE_PRIORITY_NPC
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 	wait = 0.3 SECONDS
@@ -45,6 +49,7 @@ SUBSYSTEM_DEF(humannpcpool)
 		NPC.handle_automated_movement()
 
 /datum/controller/subsystem/humannpcpool/proc/try_repopulate()
+#ifndef UNIT_TESTS
 	if (!length(GLOB.npc_spawn_points))
 		return
 
@@ -58,3 +63,4 @@ SUBSYSTEM_DEF(humannpcpool)
 			/mob/living/carbon/human/npc/business \
 		)
 		new creating_npc(get_turf(chosen_spawn_point))
+#endif


### PR DESCRIPTION

## About The Pull Request

this simply disables the NPC spawning pool stuff during unit tests. because spawning random NPCs and respawning them if they die is _asking_ for flaky failures.

also properly remove npcs from from `SShumannpcpool.currentrun` when they're destroyed and slightly cleans up `SShumannpcpool.fire()`

## Why It's Good For The Game

less overhead and issues for unit tests

## Changelog

no player-facing changes at all, only affects unit tests