### PR TITLE
fix phantom speaker targets list

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/melpominee.dm
+++ b/modular_darkpack/modules/powers/code/discipline/melpominee.dm
@@ -124,7 +124,7 @@
 		to_chat(owner, span_warning("You don't seem to know anyone you can speak to right now...")) // You have no friends.
 		return
 	// Guys we add to the input below
-	var/list/targets
+	var/list/targets = list()
 
 	for(var/mob/living/character in GLOB.player_list)
 		if(character == owner) // Skip ourselves


### PR DESCRIPTION

## About The Pull Request
the targets variable for phantom speaker was never properly initialized. this fixes that.
## Why It's Good For The Game
Makes It Work :]
## Changelog
:cl:
fix: Fixes targets list never being properly initialized for Phantom Speaker
/:cl:
