### PR TITLE
Dollar Stack Size Adjustment

### DIFF
--- a/modular_darkpack/modules/economy/code/dollar.dm
+++ b/modular_darkpack/modules/economy/code/dollar.dm
@@ -8,6 +8,7 @@
 	righthand_file = null
 	ONFLOOR_ICON_HELPER('modular_darkpack/modules/deprecated/icons/onfloor.dmi')
 	w_class = WEIGHT_CLASS_TINY
+	full_w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
 	max_amount = 1000
 	merge_type = /obj/item/stack/dollar


### PR DESCRIPTION

## About The Pull Request

Very simple 1 line change - sets the 'full' (1,000 ) dollar stack to be small size instead of deciding to up itself to a normal sized item suddenly.

Dollars are tiny, so a full stack should be a small wad of cash. This makes 1,000 dollar stacks able to fit in boxes and such but they'll still take up space.

## Why It's Good For The Game

Money was very cumbersome where 8k was enough to fully fill a bag. Now it would take a bit more than 8k, making money still cumbersome due to the fact it's a small item - not tiny - so it'll fill inventory slots up still. But now it'll fit in your pocket, your wallet, a box, etc.

## Changelog
:cl:
add: Adjusts size of 1,000 dollar stack from normal to small.
/:cl:
