### PR TITLE
Removes Darkpack ban options - Add LOOC to Abtract category

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -348,7 +348,7 @@
 			break_counter = 0
 
 		var/list/other_job_lists = list(
-			"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC", "Urgent Adminhelp"),
+			"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC", "Urgent Adminhelp", BAN_LOOC), // DARKPACK EDIT ADDITION - LOOC
 			)
 		for(var/department in other_job_lists)
 			output += "<div class='column'><label class='rolegroup [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' onClick='header_click_all_checkboxes(this)'>[department]</label><div class='content'>"
@@ -405,11 +405,6 @@
 				ROLE_VOIDWALKER,
 				ROLE_WIZARD,
 			),
-			// DARKPACK EDIT ADD START
-			"Darkpack Ban Options" = list(
-				BAN_LOOC,
-			),
-			// DARKPACK EDIT ADD END
 		)
 		for(var/department in long_job_lists)
 			output += "<div class='column'><label class='rolegroup long [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' onClick='header_click_all_checkboxes(this)'>[department]</label><div class='content'>"

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -348,7 +348,7 @@
 			break_counter = 0
 
 		var/list/other_job_lists = list(
-			"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC", "Urgent Adminhelp", BAN_LOOC), // DARKPACK EDIT ADDITION - LOOC
+			"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC", "Urgent Adminhelp", BAN_LOOC), // DARKPACK EDIT ADD - LOOC
 			)
 		for(var/department in other_job_lists)
 			output += "<div class='column'><label class='rolegroup [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' onClick='header_click_all_checkboxes(this)'>[department]</label><div class='content'>"


### PR DESCRIPTION

## About The Pull Request

Removes Darkpack ban options and adds LOOC to the Abstract category where it belongs

## Why It's Good For The Game

doesn't need its own category when it can go into Abstract

## Changelog
:cl:
admin: Removed Darkpack Ban Options and moved LOOC ban to the Abstract category.
/:cl:
