### PR TITLE
Fix for Dread Gaze Forced Retreat / Move Away

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/presence/presence.dm
+++ b/modular_darkpack/modules/powers/code/discipline/presence/presence.dm
@@ -202,7 +202,7 @@
 		to_chat(owner, span_warning("Your terrifying presence sends [target] fleeing in terror!"))
 
 		//V20's 'dread gaze' section states that with 3 or more successes targets will find themselves scratching at the walls or fleeing against their will because they are so terrified.
-		GLOB.move_manager.move_away(target, owner, 10, target.cached_multiplicative_slowdown)
+		GLOB.move_manager.move_away(target, owner, 10, target.cached_multiplicative_slowdown, 2 MINUTES)
 
 /datum/discipline_power/presence/dread_gaze/deactivate(mob/living/carbon/human/target)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

...I forgot to put a duration timeperiod effect on dread gaze. Oopsy.

## Why It's Good For The Game

Fixes an issue where you were stuck moving away from people all round long.

## Changelog
:cl:
fix: Fixes issue on Dread Gaze that was causing people to run away for entire rounds. Adjusted to 2 minute timer.
/:cl:
