### PR TITLE
VV Dropdown Admin Verbs for Curing Breaches

### DIFF
--- a/code/__DEFINES/~darkpack/masquerade.dm
+++ b/code/__DEFINES/~darkpack/masquerade.dm
@@ -4,3 +4,6 @@
 #define MASQUERADE_REASON_NPC "NPC"
 #define MASQUERADE_REASON_OBJECT "Object"
 #define MASQUERADE_REASON_OTHER "Other"
+
+#define VV_HK_CURE_BREACH "cure_breach"
+#define VV_HK_CURE_ALL_BREACHES "cure_all_breaches"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1373,11 +1373,13 @@ GAME_VERB_HIDDEN(/mob, DisDblClick, ".dblclick", argu = null as anything, sec = 
 	VV_DROPDOWN_OPTION(VV_HK_REMOVE_SPELL, "Remove Spell")
 	VV_DROPDOWN_OPTION(VV_HK_GIVE_MOB_ACTION, "Give Mob Ability")
 	VV_DROPDOWN_OPTION(VV_HK_REMOVE_MOB_ACTION, "Remove Mob Ability")
-	// DARKPACK EDIT ADD START - SPLATS
+	// DARKPACK EDIT ADD START - SPLATS & MASQUERADE
 	VV_DROPDOWN_OPTION(VV_HK_GIVE_POWER, "Give Power")
 	VV_DROPDOWN_OPTION(VV_HK_REMOVE_POWER, "Remove Power")
 	VV_DROPDOWN_OPTION(VV_HK_GIVE_ACTION, "Give Action")
 	VV_DROPDOWN_OPTION(VV_HK_REMOVE_ACTION, "Remove Action")
+	VV_DROPDOWN_OPTION(VV_HK_CURE_BREACH, "Cure Breach")
+	VV_DROPDOWN_OPTION(VV_HK_CURE_ALL_BREACHES, "Cure All Breaches")
 	// DARKPACK EDIT ADD END
 	VV_DROPDOWN_OPTION(VV_HK_GIVE_DISEASE, "Give Disease")
 	VV_DROPDOWN_OPTION(VV_HK_GODMODE, "Toggle Godmode")
@@ -1428,7 +1430,7 @@ GAME_VERB_HIDDEN(/mob, DisDblClick, ".dblclick", argu = null as anything, sec = 
 	if(href_list[VV_HK_REMOVE_SPELL])
 		return SSadmin_verbs.dynamic_invoke_verb(usr, /datum/admin_verb/remove_spell, src)
 
-	// DARKPACK EDIT ADD START - SPLATS
+	// DARKPACK EDIT ADD START - SPLATS & MASQUERADE
 	if(href_list[VV_HK_GIVE_ACTION])
 		return SSadmin_verbs.dynamic_invoke_verb(usr, /datum/admin_verb/give_action, src)
 
@@ -1440,6 +1442,12 @@ GAME_VERB_HIDDEN(/mob, DisDblClick, ".dblclick", argu = null as anything, sec = 
 
 	if(href_list[VV_HK_REMOVE_POWER])
 		return SSadmin_verbs.dynamic_invoke_verb(usr, /datum/admin_verb/remove_power, src)
+
+	if(href_list[VV_HK_CURE_BREACH])
+		return SSadmin_verbs.dynamic_invoke_verb(usr, /datum/admin_verb/cure_breach, src)
+
+	if(href_list[VV_HK_CURE_ALL_BREACHES])
+		return SSadmin_verbs.dynamic_invoke_verb(usr, /datum/admin_verb/cure_all_breaches, src)
 	// DARKPACK EDIT ADD END
 
 	if(href_list[VV_HK_GIVE_DISEASE])

--- a/modular_darkpack/modules/masquerade/code/masquerade_admin.dm
+++ b/modular_darkpack/modules/masquerade/code/masquerade_admin.dm
@@ -7,3 +7,5 @@
 			SSmasquerade.masquerade_reinforce(null, src, reason)
 		if(-1)
 			SSmasquerade.masquerade_breach(null, src, reason)
+
+//admin_verbs.dm for cure_breach and cure_all_breaches admin verbs

--- a/modular_darkpack/modules/splats/code/powers/admin_verbs.dm
+++ b/modular_darkpack/modules/splats/code/powers/admin_verbs.dm
@@ -121,11 +121,11 @@ ADMIN_VERB(cure_breach, R_FUN, "Cure Masquerade Breach", ADMIN_VERB_NO_DESCRIPTI
 	var/atom/chosen_breach_to_restore = tgui_input_list(user, "Cure Masquerade Breach", "Choose a breach source to cure", breaches)
 	if(!chosen_breach_to_restore)
 		return
-	chosen_breach_to_restore.observe_masquerade_reinforce(breached_player)
+	SEND_SIGNAL(chosen_breach_to_restore, COMSIG_MASQUERADE_REINFORCE, breached_player)
 
 ADMIN_VERB(cure_all_breaches, R_FUN, "Cure All Masquerade Breaches", ADMIN_VERB_NO_DESCRIPTION, ADMIN_CATEGORY_HIDDEN, mob/breached_player)
 	for(var/list/masquerade_breach in SSmasquerade.masquerade_breachers)
 		if(masquerade_breach[1] != breached_player)
 			continue
 		var/atom/masquerade_breach_source = masquerade_breach[2]
-		masquerade_breach_source.observe_masquerade_reinforce(breached_player)
+		SEND_SIGNAL(masquerade_breach_source, COMSIG_MASQUERADE_REINFORCE, breached_player)

--- a/modular_darkpack/modules/splats/code/powers/admin_verbs.dm
+++ b/modular_darkpack/modules/splats/code/powers/admin_verbs.dm
@@ -112,3 +112,20 @@ ADMIN_VERB(remove_action, R_FUN, "Remove Action", ADMIN_VERB_NO_DESCRIPTION, ADM
 	message_admins("[key_name_admin(user)] removed the action [chosen_action] from [key_name_admin(removal_target)].")
 	BLACKBOX_LOG_ADMIN_VERB("Remove Action")
 
+ADMIN_VERB(cure_breach, R_FUN, "Cure Masquerade Breach", ADMIN_VERB_NO_DESCRIPTION, ADMIN_CATEGORY_HIDDEN, mob/breached_player)
+	var/list/breaches = list()
+	for(var/list/masquerade_breach in SSmasquerade.masquerade_breachers)
+		if(masquerade_breach[1] != breached_player)
+			continue
+		breaches += masquerade_breach[2]
+	var/atom/chosen_breach_to_restore = tgui_input_list(user, "Cure Masquerade Breach", "Choose a breach source to cure", breaches)
+	if(!chosen_breach_to_restore)
+		return
+	chosen_breach_to_restore.observe_masquerade_reinforce(breached_player)
+
+ADMIN_VERB(cure_all_breaches, R_FUN, "Cure All Masquerade Breaches", ADMIN_VERB_NO_DESCRIPTION, ADMIN_CATEGORY_HIDDEN, mob/breached_player)
+	for(var/list/masquerade_breach in SSmasquerade.masquerade_breachers)
+		if(masquerade_breach[1] != breached_player)
+			continue
+		var/atom/masquerade_breach_source = masquerade_breach[2]
+		masquerade_breach_source.observe_masquerade_reinforce(breached_player)


### PR DESCRIPTION
## About The Pull Request

VV dropdown admin verbs for curing breaches or all breaches

## Why It's Good For The Game

useful for fraudulent player-made masq breaches, bugs

## Changelog

:cl:

admin: admins can now use the vv dropdown menu to 'cure breach' (a single one) or 'cure all breaches' (clears all breaches) on any mob that has breached

/:cl:
